### PR TITLE
Removed setting the wt=ruby in params and fixed url path in build_request

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -184,7 +184,7 @@ class RSolr::Client
     opts[:proxy] = proxy unless proxy.nil?
     opts[:method] ||= :get
     raise "The :data option can only be used if :method => :post" if opts[:method] != :post and opts[:data]
-    opts[:params] = opts[:params].nil? ? {:wt => :ruby} : {:wt => :ruby}.merge(opts[:params])
+    opts[:params] = opts[:params].nil? ? {} : opts[:params]
     query = RSolr::Uri.params_to_solr(opts[:params]) unless opts[:params].empty?
     opts[:query] = query
     if opts[:data].is_a? Hash

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -161,7 +161,7 @@ describe "RSolr::Client" do
   
   context "adapt_response" do
     include ClientHelper
-    it 'should not try to evaluate ruby when the :qt is not :ruby' do
+    it 'should not try to evaluate ruby when the :wt is not :ruby' do
       body = '{:time=>"NOW"}'
       result = client.adapt_response({:params=>{}}, {:status => 200, :body => body, :headers => {}})
       result.should == body
@@ -190,9 +190,10 @@ describe "RSolr::Client" do
         :data => "data",
         :headers => {}
       )
-      [/fq=0/, /fq=1/, /q=test/, /wt=ruby/].each do |pattern|
+      [/fq=0/, /fq=1/, /q=test/].each do |pattern|
         result[:query].should match pattern
       end
+
       result[:data].should == "data"
       result[:headers].should == {}
     end
@@ -203,7 +204,6 @@ describe "RSolr::Client" do
         :data => {:q=>'test', :fq=>[0,1]},
         :headers => {}
       )
-      result[:query].should == "wt=ruby"
       [/fq=0/, /fq=1/, /q=test/].each do |pattern|
         result[:data].should match pattern
       end

--- a/spec/api/pagination_spec.rb
+++ b/spec/api/pagination_spec.rb
@@ -20,8 +20,7 @@ describe "RSolr::Pagination" do
         #:per_page => 10,
         :params => {
           "rows" => 10,
-          "start" => 0,
-          :wt => :ruby
+          "start" => 0
         }
       }))
       c.paginate 1, 10, "select"


### PR DESCRIPTION
Hello,

First of all, apologies for submitting two different commits in the same pull request. 

1) Removed setting the wt=ruby
I am not entirely sure, why this is being done probably due to lack of my understanding of RSolr but in my opinion, this should come from the user as opposed to set in the code by default. I did not see any specs around it. Please enlighten.

2) Fixed url path
In build_request method, the merge was removing the /solr bit from the original supplied url. So, instead of

<pre>
http://localhost:9999/solr/select?q=a
</pre>


it was this:

<pre>
http://localhost:9999/select?q=a
</pre>


Thanks.
