### PR TITLE
Configurable read_timeout on Net::HTTP

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -155,6 +155,7 @@ class RSolr::Client
   # then passes the request/response into +adapt_response+.
   def send_and_receive path, opts
     request_context = build_request path, opts
+    request_context[:read_timeout] = @options[:read_timeout]
     execute request_context
   end
   

--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -8,7 +8,7 @@ class RSolr::Connection
   # send a request,
   # then return the standard rsolr response hash {:status, :body, :headers}
   def execute client, request_context
-    h = http request_context[:uri], request_context[:proxy]
+    h = http request_context[:uri], request_context[:proxy], request_context[:read_timeout]
     request = setup_raw_request request_context
     request.body = request_context[:data] if request_context[:method] == :post and request_context[:data]
     begin
@@ -26,7 +26,7 @@ class RSolr::Connection
   protected
 
   # This returns a singleton of a Net::HTTP or Net::HTTP.Proxy request object.
-  def http uri, proxy = nil
+  def http uri, proxy = nil, read_timeout = nil
     @http ||= (
       http = if proxy
         proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
@@ -35,6 +35,7 @@ class RSolr::Connection
         Net::HTTP.new uri.host, uri.port
       end
       http.use_ssl = uri.port == 443 || uri.instance_of?(URI::HTTPS)
+      http.read_timeout = read_timeout if read_timeout
       http
     )
   end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -5,7 +5,7 @@ describe "RSolr::Client" do
     def client
       @client ||= (
         connection = RSolr::Connection.new
-        RSolr::Client.new connection, :url => "http://localhost:9999/solr"
+        RSolr::Client.new connection, :url => "http://localhost:9999/solr", :read_timeout => 42
       )
     end
   end
@@ -22,6 +22,13 @@ describe "RSolr::Client" do
       [:get, :post, :head].each do |meth|
         client.connection.should_receive(:execute).
             and_return({:status => 200, :body => "{}", :headers => {}})
+        client.send_and_receive '', :method => meth, :params => {}, :data => nil, :headers => {}
+      end
+    end
+
+    it "should be timeout aware" do
+      [:get, :post, :head].each do |meth|
+        client.connection.should_receive(:execute).with(client, hash_including(:read_timeout => 42))
         client.send_and_receive '', :method => meth, :params => {}, :data => nil, :headers => {}
       end
     end

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -11,5 +11,23 @@ describe "RSolr::Connection" do
     req.each_header{|k,v| headers[k] = v}
     headers.should == {"content-type"=>"text/xml"}
   end
+
+  context "read timeout configuration" do
+    let(:client) { mock.as_null_object }
+
+    subject { RSolr::Connection.new } 
+
+    it "should configure Net:HTTP read_timeout" do
+      subject.execute client, {:uri => URI.parse("http://localhost/some_uri"), :method => :get, :read_timeout => 42}
+      http = subject.instance_variable_get(:@http)
+      http.read_timeout.should == 42
+    end
+
+    it "should use Net:HTTP default read_timeout if not specified" do
+      subject.execute client, {:uri => URI.parse("http://localhost/some_uri"), :method => :get}
+      http = subject.instance_variable_get(:@http)
+      http.read_timeout.should == 60
+    end
+  end
   
 end


### PR DESCRIPTION
Changed `RSolr::Client` and `RSolr::Connection` to be able to configure a different `read_timeout` value for `Net::HTTP`.

With help from @caiofilipini
