### PR TITLE
pass UTF-8 encoding for urlencoded data

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -142,7 +142,7 @@ class RSolr::Client
   # "opts" : A hash, which can contain the following keys:
   #   :method : required - the http method (:get, :post or :head)
   #   :params : optional - the query string params in hash form
-  #   :data : optional - post data -- if a hash is given, it's sent as "application/x-www-form-urlencoded"
+  #   :data : optional - post data -- if a hash is given, it's sent as "application/x-www-form-urlencoded; charset=UTF-8"
   #   :headers : optional - hash of request headers
   # All other options are passed right along to the connection's +send_and_receive+ method (:get, :post, or :head)
   # 
@@ -191,7 +191,7 @@ class RSolr::Client
     if opts[:data].is_a? Hash
       opts[:data] = RSolr::Uri.params_to_solr opts[:data]
       opts[:headers] ||= {}
-      opts[:headers]['Content-Type'] ||= 'application/x-www-form-urlencoded'
+      opts[:headers]['Content-Type'] ||= 'application/x-www-form-urlencoded; charset=UTF-8'
     end
     opts[:path] = path
     opts[:uri] = base_uri.merge(path.to_s + (query ? "?#{query}" : "")) if base_uri

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -204,7 +204,7 @@ describe "RSolr::Client" do
       result[:headers].should == {}
     end
     
-    it "should set the Content-Type header to application/x-www-form-urlencoded if a hash is passed in to the data arg" do
+    it "should set the Content-Type header to application/x-www-form-urlencoded; charset=UTF-8 if a hash is passed in to the data arg" do
       result = client.build_request('select',
         :method => :post,
         :data => {:q=>'test', :fq=>[0,1]},
@@ -215,7 +215,7 @@ describe "RSolr::Client" do
         result[:data].should match pattern
       end
       result[:data].should_not match /wt=ruby/
-      result[:headers].should == {"Content-Type" => "application/x-www-form-urlencoded"}
+      result[:headers].should == {"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
     end
     
   end


### PR DESCRIPTION
Hi, Matt
I found one issue related to queries posted to "tomcatted" solr. For example: 

``` ruby
solr.post 'select', :data => {:q => 'тест'}
```

will produce 

``` ruby
{"responseHeader"=>{"status"=>0, "QTime"=>1, "params"=>{"q"=>"Ñ\u0082ÐµÑ\u0081Ñ\u0082", "wt"=>"ruby"}}, "response"=>{"numFound"=>0, "start"=>0, "docs"=>[]}}
```

and you can see that tomcat broke `q` parameter

That is because tomcat by default assumes that posted data encoded in ASCII, so posting search queries with UTF-8 chars breaks results. 

This issue is not related to Jetty deployments, because Jetty assumes that UTF-8 encoding by default. So this fix will not break any existing installations.
