### PR TITLE
Adding configuration for setting Net::HTTP.open_timeout

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -155,7 +155,9 @@ class RSolr::Client
   # then passes the request/response into +adapt_response+.
   def send_and_receive path, opts
     request_context = build_request path, opts
-    request_context[:read_timeout] = @options[:read_timeout]
+    [:open_timeout, :read_timeout].each do |k|
+      request_context[k] = @options[k]
+    end
     execute request_context
   end
   

--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -8,7 +8,7 @@ class RSolr::Connection
   # send a request,
   # then return the standard rsolr response hash {:status, :body, :headers}
   def execute client, request_context
-    h = http request_context[:uri], request_context[:proxy], request_context[:read_timeout]
+    h = http request_context[:uri], request_context[:proxy], request_context[:read_timeout], request_context[:open_timeout]
     request = setup_raw_request request_context
     request.body = request_context[:data] if request_context[:method] == :post and request_context[:data]
     begin
@@ -26,7 +26,7 @@ class RSolr::Connection
   protected
 
   # This returns a singleton of a Net::HTTP or Net::HTTP.Proxy request object.
-  def http uri, proxy = nil, read_timeout = nil
+  def http uri, proxy = nil, read_timeout = nil, open_timeout = nil
     @http ||= (
       http = if proxy
         proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
@@ -36,6 +36,7 @@ class RSolr::Connection
       end
       http.use_ssl = uri.port == 443 || uri.instance_of?(URI::HTTPS)
       http.read_timeout = read_timeout if read_timeout
+      http.open_timeout = open_timeout if open_timeout
       http
     )
   end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -5,7 +5,7 @@ describe "RSolr::Client" do
     def client
       @client ||= (
         connection = RSolr::Connection.new
-        RSolr::Client.new connection, :url => "http://localhost:9999/solr", :read_timeout => 42
+        RSolr::Client.new connection, :url => "http://localhost:9999/solr", :read_timeout => 42, :open_timeout=>43
       )
     end
   end
@@ -28,7 +28,7 @@ describe "RSolr::Client" do
 
     it "should be timeout aware" do
       [:get, :post, :head].each do |meth|
-        client.connection.should_receive(:execute).with(client, hash_including(:read_timeout => 42))
+        client.connection.should_receive(:execute).with(client, hash_including(:read_timeout => 42, :open_timeout=>43))
         client.send_and_receive '', :method => meth, :params => {}, :data => nil, :headers => {}
       end
     end

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -29,5 +29,23 @@ describe "RSolr::Connection" do
       http.read_timeout.should == 60
     end
   end
+
+  context "open timeout configuration" do
+    let(:client) { mock.as_null_object }
+
+    subject { RSolr::Connection.new } 
+
+    it "should configure Net:HTTP open_timeout" do
+      subject.execute client, {:uri => URI.parse("http://localhost/some_uri"), :method => :get, :open_timeout => 42}
+      http = subject.instance_variable_get(:@http)
+      http.open_timeout.should == 42
+    end
+
+    it "should use Net:HTTP default open_timeout if not specified" do
+      subject.execute client, {:uri => URI.parse("http://localhost/some_uri"), :method => :get}
+      http = subject.instance_variable_get(:@http)
+      http.open_timeout.should == nil
+    end
+  end
   
 end


### PR DESCRIPTION
In issue #154, there is was a request for timeouts.  A previous patch added a read_timeout configuration, but I would also like to be able to set the [open_timeout](http://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html#attribute-i-open_timeout).  This commit allows the caller to set the open_timeout if desired.
