### PR TITLE
Added configuration so that URL escaping can be turned on

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -1,6 +1,6 @@
 class RSolr::Client
   
-  attr_reader :connection, :uri, :proxy, :options
+  attr_reader :connection, :uri, :proxy, :options, :escape
   
   def initialize connection, options = {}
     @proxy = @uri = nil
@@ -14,6 +14,7 @@ class RSolr::Client
         proxy_url << "/" unless proxy_url.nil? or proxy_url[-1] == ?/
         @proxy = RSolr::Uri.create proxy_url if proxy_url
       end
+      @escape = options[:escape].nil? ? true : options[:escape]
     end
     @options = options
   end
@@ -188,7 +189,7 @@ class RSolr::Client
     opts[:method] ||= :get
     raise "The :data option can only be used if :method => :post" if opts[:method] != :post and opts[:data]
     opts[:params] = opts[:params].nil? ? {:wt => :ruby} : {:wt => :ruby}.merge(opts[:params])
-    query = RSolr::Uri.params_to_solr(opts[:params]) unless opts[:params].empty?
+    query = RSolr::Uri.params_to_solr(opts[:params], escape) unless opts[:params].empty?
     opts[:query] = query
     if opts[:data].is_a? Hash
       opts[:data] = RSolr::Uri.params_to_solr opts[:data]

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -217,6 +217,14 @@ describe "RSolr::Client" do
       result[:data].should_not match /wt=ruby/
       result[:headers].should == {"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
     end
+
+    it "should not escape the params if escape == false" do
+      connection = RSolr::Connection.new
+      client = RSolr::Client.new connection, :url => "http://localhost/solr", :escape=>false
+      result = client.build_request('select', :method => :get, :params=>{:q=>"test+no+escape"})
+      client.escape.should be_false
+      result[:uri].query.include?("test+no+escape").should be_true
+    end
     
   end
   


### PR DESCRIPTION
Legacy Solr clients don't want escaped URLs, this pull request allows a client to be configured so that it will generate non-escaped URLs. 
