### PR TITLE
rsolr doesn't work on rubinius

### DIFF
--- a/lib/rsolr/response.rb
+++ b/lib/rsolr/response.rb
@@ -5,8 +5,8 @@ module RSolr::Response
       base["response"]["docs"].tap do |d|
         d.extend PaginatedDocSet
         d.per_page = base.request[:params]["rows"]
-        d.start = base.request[:params]["start"]
-        d.total = base["response"]["numFound"].to_s.to_i
+        d.p_start = base.request[:params]["start"]
+        d.p_total = base["response"]["numFound"].to_s.to_i
       end
     end
   end
@@ -14,18 +14,18 @@ module RSolr::Response
   # A response module which gets mixed into the solr ["response"]["docs"] array.
   module PaginatedDocSet
 
-    attr_accessor :start, :per_page, :total
+    attr_accessor :p_start, :per_page, :p_total
 
     # Returns the current page calculated from 'rows' and 'start'
     def current_page
-      return 1 if start < 1
+      return 1 if p_start < 1
       per_page_normalized = per_page < 1 ? 1 : per_page
-      @current_page ||= (start / per_page_normalized).ceil + 1
+      @current_page ||= (p_start / per_page_normalized).ceil + 1
     end
 
     # Calcuates the total pages from 'numFound' and 'rows'
     def total_pages
-      @total_pages ||= per_page > 0 ? (total / per_page.to_f).ceil : 1
+      @total_pages ||= per_page > 0 ? (p_total / per_page.to_f).ceil : 1
     end
 
     # returns the previous page number or 1


### PR DESCRIPTION
Currently the gem doesn't work on Rubinius the issue is on PaginatedDocSet where start and total are actual fields in Rubinius Array implementation, its an easy fix just prefix those fields.
