### PR TITLE
Fix connection refused errors in specs + add basic auth support

### DIFF
--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -67,6 +67,7 @@ class RSolr::Connection
       raw_request = http_method.new request_context[:uri].request_uri
     # end
     raw_request.initialize_http_header headers
+    raw_request.basic_auth(request_context[:uri].user, request_context[:uri].password) if request_context[:uri].user && request_context[:uri].password
     raw_request
   end
 

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'base64'
+
 describe "RSolr::Connection" do
   
   context "setup_raw_request" do
@@ -56,4 +58,19 @@ describe "RSolr::Connection" do
     end
   end
   
+  describe "basic auth support" do
+    let(:http) { mock(Net::HTTP).as_null_object }
+    
+    before do
+      Net::HTTP.stub(:new) { http }
+    end
+    
+    it "sets the authorization header" do
+      http.should_receive(:request) do |request|
+        request.fetch('authorization').should == "Basic #{Base64.encode64("joe:pass")}".strip
+        mock(Net::HTTPResponse).as_null_object
+      end
+      RSolr::Connection.new.execute nil, :uri => URI.parse("http://joe:pass@localhost:8983/solr"), :method => :get
+    end
+  end
 end


### PR DESCRIPTION
Hi,

The four timeout tests that have been added in 1.0.7 are failing because they try to connect to http://localhost/some_uri. Discovered it while adding the basic auth support.
