### PR TITLE
Raise a custom exception for Errno::ECONNREFUSED

### DIFF
--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -15,10 +15,12 @@ class RSolr::Connection
       response = h.request request
       charset = response.type_params["charset"]
       {:status => response.code.to_i, :headers => response.to_hash, :body => force_charset(response.body, charset)}
+    rescue Errno::ECONNREFUSED
+      raise RSolr::Error::ConnectionRefused
     # catch the undefined closed? exception -- this is a confirmed ruby bug
     rescue NoMethodError
       $!.message == "undefined method `closed?' for nil:NilClass" ?
-        raise(Errno::ECONNREFUSED.new) :
+        raise(RSolr::Error::ConnectionRefused) :
         raise($!)
     end
   end

--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -37,6 +37,9 @@ module RSolr::Error
     end
     
   end
+
+  class ConnectionRefused < ::Errno::ECONNREFUSED
+  end
   
   class Http < RuntimeError
     

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -14,6 +14,20 @@ describe "RSolr::Connection" do
     headers.should == {"content-type"=>"text/xml"}
   end
 
+  context "when the connection is refused" do
+    subject { RSolr::Connection.new }
+
+    it "raises a custom exception" do
+      http_stub = double("Net:HTTP")
+      http_stub.stub(:request){ raise(Errno::ECONNREFUSED.new) }
+
+      subject.stub(:setup_raw_request){ http_stub }
+      subject.stub(:http){ Net::HTTP.new("localhost", 80) }
+
+      lambda{ subject.execute(nil,{}) }.should raise_error(RSolr::Error::ConnectionRefused)
+    end
+  end
+
   context "read timeout configuration" do
     let(:client) { mock.as_null_object }
 


### PR DESCRIPTION
This helps distinguish which external service is unreachable. Test included.