### PR TITLE
append new path to existing path in URI rather than replacing existing path - for 2.x

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -196,7 +196,7 @@ class RSolr::Client
       opts[:headers]['Content-Type'] ||= 'application/x-www-form-urlencoded; charset=UTF-8'
     end
     opts[:path] = path
-    opts[:uri] = base_uri.merge(path.to_s + (query ? "?#{query}" : "")) if base_uri
+    opts[:uri] = base_uri.merge((base_uri.path.nil? ? '' : base_uri.path) +  path.to_s + (query ? "?#{query}" : "")) if base_uri
     opts
   end
   


### PR DESCRIPTION
I am surprised how this has been working for others but it my case when the base url is "http://localhost:8983/solr" and my request handler is "/select", rsolr issues a request to "http://localhost:8983/select" rather than to "http://localhost:8983/solr/select". 

I had to make this little change so that "select" gets appended to existing path "/solr" to result in "solr/select/" rather than overwrite "/solr" to result in "/select".
