### PR TITLE
Adding request context to exception message

### DIFF
--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -15,6 +15,8 @@ class RSolr::Connection
       response = h.request request
       charset = response.type_params["charset"]
       {:status => response.code.to_i, :headers => response.to_hash, :body => force_charset(response.body, charset)}
+    rescue Errno::ECONNREFUSED => e
+      raise(Errno::ECONNREFUSED.new(request_context.inspect))
     # catch the undefined closed? exception -- this is a confirmed ruby bug
     rescue NoMethodError
       $!.message == "undefined method `closed?' for nil:NilClass" ?

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -57,6 +57,27 @@ describe "RSolr::Connection" do
       subject.execute client, {:uri => URI.parse("http://localhost/some_uri"), :method => :get}
     end
   end
+
+  context "connection refused" do
+    let(:client) { mock.as_null_object }
+
+    let(:http) { mock(Net::HTTP).as_null_object }
+    let(:request_context) {
+      {:uri => URI.parse("http://localhost/some_uri"), :method => :get, :open_timeout => 42}
+    }
+    subject { RSolr::Connection.new } 
+
+    before do
+      Net::HTTP.stub(:new) { http }
+    end
+
+    it "should configure Net:HTTP open_timeout" do
+      http.should_receive(:request).and_raise(Errno::ECONNREFUSED)
+      lambda {
+        subject.execute client, request_context
+      }.should raise_error(Errno::ECONNREFUSED, /#{request_context}/)
+    end
+  end
   
   describe "basic auth support" do
     let(:http) { mock(Net::HTTP).as_null_object }


### PR DESCRIPTION
Prior to this patch, I would receive the following exception:

```
Errno::ECONNREFUSED (Connection refused - connect(2))
```

With this patch, I receive the equivalent of:

```
Errno::ECONNREFUSED: Connection refused - {
  :uri=>#<URI::HTTP:0x007fd5093b22a8 URL:http://localhost/some_uri>,
  :method=>:get,
  :open_timeout=>42
}
``
```
