### PR TITLE
add license information to the gemspec

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rdoc', '~> 3.9.4'
   s.add_development_dependency 'rspec', '~> 2.6.0'
+  s.license      = "Apache License 2.0"
 end


### PR DESCRIPTION
this way we can suse it when using the rubygems.org api
