### PR TITLE
Fixed connection to Solr through proxy

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -26,7 +26,7 @@ class RSolr::Client
   # returns the uri proxy if present,
   # otherwise just the uri object.
   def base_uri
-    @proxy ? @proxy : @uri
+    @uri
   end
   
   # Create the get, post, and head methods

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -8,6 +8,13 @@ describe "RSolr::Client" do
         RSolr::Client.new connection, :url => "http://localhost:9999/solr", :read_timeout => 42, :open_timeout=>43
       )
     end
+
+    def client_with_proxy
+      @client_with_proxy ||= (
+        connection = RSolr::Connection.new
+        RSolr::Client.new connection, :url => "http://localhost:9999/solr", :proxy => 'http://localhost:8080', :read_timeout => 42, :open_timeout=>43
+      )
+    end
   end
   
   context "initialize" do
@@ -249,7 +256,15 @@ describe "RSolr::Client" do
       result[:data].should_not match /wt=ruby/
       result[:headers].should == {"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
     end
-    
+   
+    it "should properly handle proxy configuration" do
+      result = client_with_proxy.build_request('select',
+        :method => :post,
+        :data => {:q=>'test', :fq=>[0,1]},
+        :headers => {}
+      )
+      result[:uri].to_s.should match /^http:\/\/localhost:9999\/solr\//
+    end 
   end
   
 end


### PR DESCRIPTION
I discovered an issue where when you specify a proxy via RSolr#connect the URL used to connect to the Solr server is changed to the proxy host/port.

Consider the following:
```ruby
solr = RSolr.connect({ 
      :url => 'http://localhost:10000/solr/mycollection',
      :proxy => 'http://localhost:8080'
    })
```

Calling solr#add would result in an HTTP request similar to:
http://localhost:8080/solr/mycollection/update...

The culprit seems to be the base_uri method in the client.rb file. I don't know why, but when a proxy is specified it uses the proxy host & port instead of the given Solr host & port. This seems incorrect to me. In the http method in connection.rb it correctly uses a proxy shim thus resulting in an HTTP CONNECT through the proxy (which is exactly what we want).
