### PR TITLE
Replace autoload with explicit requires for thread safety.

### DIFF
--- a/lib/rsolr.rb
+++ b/lib/rsolr.rb
@@ -1,10 +1,6 @@
-$: << "#{File.dirname(__FILE__)}" unless $:.include? File.dirname(__FILE__)
-
-require 'rubygems'
-
 module RSolr
   
-  %W(Response Char Client Error Connection Uri Xml).each{|n|autoload n.to_sym, "rsolr/#{n.downcase}"}
+  Dir.glob(File.expand_path("../rsolr/*.rb", __FILE__)).each{|rb_file| require(rb_file)}
   
   def self.version; "1.0.9" end
   


### PR DESCRIPTION
I've been having mysterious problems with RSolr classes "losing" methods in a busy production environment. I've traced it down to the use of autoload in the RSolr module to load classes on demand. This method is not thread safe so when multiple threads try to load RSolr at the same time I end up with inconsistent classes in memory.

The fix is to use require to load the files when RSolr is required. I think this should be fine since if anyone is using RSolr they should eventually want all the classes loaded anyway.
