### PR TITLE
Use full path for update/add documents

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -64,7 +64,7 @@ class RSolr::Client
   def update opts = {}
     opts[:headers] ||= {}
     opts[:headers]['Content-Type'] ||= 'text/xml'
-		post Sunspot.config.solr.url + '/update/', opts
+    post Sunspot.config.solr.url + '/update/', opts
   end
   
   # 


### PR DESCRIPTION
Rsolr was throwing 404 not found error because update path needed to be full path for adding documents
