### PR TITLE
RSolr::Response#with_indifferent_access should still be an RSolr::Response

### DIFF
--- a/lib/rsolr/response.rb
+++ b/lib/rsolr/response.rb
@@ -11,6 +11,14 @@ module RSolr::Response
     end
   end
   
+  def with_indifferent_access
+    if {}.respond_to?(:with_indifferent_access)
+      super.extend RSolr::Response
+    else
+      raise NoMethodError, "undefined method `with_indifferent_access' for #{self.inspect}:#{self.class.name}"
+    end
+  end
+
   # A response module which gets mixed into the solr ["response"]["docs"] array.
   module PaginatedDocSet
 

--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.add_dependency 'builder', '>= 2.1.2'
+  s.add_development_dependency 'activesupport'
   s.add_development_dependency 'nokogiri', '>= 1.4.0'
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rdoc', '~> 3.9.4'

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -220,6 +220,32 @@ describe "RSolr::Client" do
   
   end
   
+  context "indifferent access" do
+    include ClientHelper
+    it "should raise a NoMethodError if the #with_indifferent_access extension isn't loaded" do
+      # TODO: Find a less implmentation-tied way to test this
+      Hash.any_instance.should_receive(:respond_to?).with(:with_indifferent_access).and_return(false)
+      body = "{'foo'=>'bar'}"
+      result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
+      lambda { result.with_indifferent_access }.should raise_error NoMethodError
+    end
+
+    it "should provide indifferent access" do
+      require 'active_support/core_ext/hash/indifferent_access'
+      body = "{'foo'=>'bar'}"
+      result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
+      indifferent_result = result.with_indifferent_access
+
+      result.should be_a(RSolr::Response)
+      result['foo'].should == 'bar'
+      result[:foo].should be_nil
+
+      indifferent_result.should be_a(RSolr::Response)
+      indifferent_result['foo'].should == 'bar'
+      indifferent_result[:foo].should == 'bar'
+    end
+  end
+
   context "build_request" do
     include ClientHelper
     it 'should return a request context array' do


### PR DESCRIPTION
This is another take on #59 which eliminates the ambiguous, automatic extending of the response. This merely makes `#with_indifferent_access` available to `RSolr::Response` if the correct ActiveSupport extension is loaded, and makes sure that the resulting indifferent Hash is also an `RSolr::Response`.
