### PR TITLE
Fix "can't modify frozen object" error

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -283,7 +283,7 @@ class RSolr::Client
     raise RSolr::Error::Http.new request, response unless [200,302].include? response[:status]
 
     result = if respond_to? "evaluate_#{request[:params][:wt]}_response", true
-      send "evaluate_#{request[:params][:wt]}_response", request, response
+      send("evaluate_#{request[:params][:wt]}_response", request, response) || {}
     else
       response[:body]
     end


### PR DESCRIPTION
When a `head` request is made the `response[:body]` is `nil` which means
the `result` variable is `nil` which throws a "can't modify frozen
object" error on `result.extend`.

returning a hash rather than `nil` seemed like the best fix with my limited knowledge of how RSolr works but you may be able to come up with a better solution.

To reproduce this try

    RSolr.connect(url: solr_url).head('admin/ping')