### PR TITLE
Silence RSpec's deprecation warnings.

### DIFF
--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -15,9 +15,9 @@ describe "RSolr::Connection" do
   end
 
   context "read timeout configuration" do
-    let(:client) { mock.as_null_object }
+    let(:client) { double.as_null_object }
 
-    let(:http) { mock(Net::HTTP).as_null_object }
+    let(:http) { double(Net::HTTP).as_null_object }
 
     subject { RSolr::Connection.new } 
 
@@ -37,9 +37,9 @@ describe "RSolr::Connection" do
   end
 
   context "open timeout configuration" do
-    let(:client) { mock.as_null_object }
+    let(:client) { double.as_null_object }
 
-    let(:http) { mock(Net::HTTP).as_null_object }
+    let(:http) { double(Net::HTTP).as_null_object }
 
     subject { RSolr::Connection.new } 
 
@@ -59,9 +59,9 @@ describe "RSolr::Connection" do
   end
 
   context "connection refused" do
-    let(:client) { mock.as_null_object }
+    let(:client) { double.as_null_object }
 
-    let(:http) { mock(Net::HTTP).as_null_object }
+    let(:http) { double(Net::HTTP).as_null_object }
     let(:request_context) {
       {:uri => URI.parse("http://localhost/some_uri"), :method => :get, :open_timeout => 42}
     }
@@ -81,7 +81,7 @@ describe "RSolr::Connection" do
   end
   
   describe "basic auth support" do
-    let(:http) { mock(Net::HTTP).as_null_object }
+    let(:http) { double(Net::HTTP).as_null_object }
     
     before do
       Net::HTTP.stub(:new) { http }
@@ -90,7 +90,7 @@ describe "RSolr::Connection" do
     it "sets the authorization header" do
       http.should_receive(:request) do |request|
         request.fetch('authorization').should == "Basic #{Base64.encode64("joe:pass")}".strip
-        mock(Net::HTTPResponse).as_null_object
+        double(Net::HTTPResponse).as_null_object
       end
       RSolr::Connection.new.execute nil, :uri => URI.parse("http://joe:pass@localhost:8983/solr"), :method => :get
     end

--- a/spec/api/error_spec.rb
+++ b/spec/api/error_spec.rb
@@ -10,7 +10,7 @@ describe "RSolr::Error" do
     before do
       response_lines = (1..15).to_a.map { |i| "line #{i}" }
 
-      @request  = mock :[] => "mocked"
+      @request  = double :[] => "mocked"
       @response = {
         :body   => "<pre>" + response_lines.join("\n") + "</pre>",
         :status => 400
@@ -34,7 +34,7 @@ describe "RSolr::Error" do
     before do
       response_lines = (1..15).to_a.map { |i| "line #{i}" }
 
-      @request  = mock :[] => "mocked"
+      @request  = double :[] => "mocked"
       @response = {
         :body   => response_lines.join("\n"),
         :status => 400

--- a/spec/api/xml_spec.rb
+++ b/spec/api/xml_spec.rb
@@ -4,12 +4,11 @@ require 'nokogiri'
 describe "RSolr::Xml" do
   
   let(:generator){ RSolr::Xml::Generator.new }
-  let(:builder_engines) do
-    { 
-      :builder   => { :val => false, :class => Builder::XmlMarkup, :engine => Builder::XmlMarkup.new(:indent => 0, :margin => 0, :encoding => 'UTF-8') },
-      :nokogiri  => { :val => true,  :class => Nokogiri::XML::Builder, :engine => Nokogiri::XML::Builder.new }
-    }
-  end
+
+  builder_engines = { 
+    :builder   => { :val => false, :class => Builder::XmlMarkup, :engine => Builder::XmlMarkup.new(:indent => 0, :margin => 0, :encoding => 'UTF-8') },
+    :nokogiri  => { :val => true,  :class => Nokogiri::XML::Builder, :engine => Nokogiri::XML::Builder.new }
+  }
 
   [:builder,:nokogiri].each do |engine_name|
     describe engine_name do


### PR DESCRIPTION
RSpec deprecated `mock` in favour of `double` [a year ago](/rspec/rspec-mocks/commit/843a40f). In addition to that, `let` and `subject` declarations are not intended to be called in a `before(:all)` hook. This is deprecated behavior that will not be supported in RSpec 3.

Version 2.6 as specified in the Gemfile is three years old.
