### PR TITLE
Client HEAD requests and response evaluation.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -151,17 +151,22 @@ Delete by array of queries
   solr.optimize, :optimize_attributes => {}
 
 == Response Formats
-The default response format is Ruby. When the :wt param is set to :ruby, the response is eval'd resulting in a Hash. You can get a raw response by setting the :wt to "ruby" - notice, the string -- not a symbol. RSolr will eval the Ruby string ONLY if the :wt value is :ruby. All other response formats are available as expected, :wt=>'xml' etc..
+The default response format is Ruby. When the :wt param is set to :ruby, the response is eval'd resulting in a Hash. You can get a raw response by setting the :wt to "ruby" - notice, the string -- not a symbol. RSolr will eval the response body ONLY if the :wt value is a symbol. All other response formats are available as expected, :wt=>'xml' etc., and return the raw string.
 
 ===Evaluated Ruby (default)
   solr.get 'select', :params => {:wt => :ruby} # notice :ruby is a Symbol
 ===Raw Ruby
   solr.get 'select', :params => {:wt => 'ruby'} # notice 'ruby' is a String
 
-===XML:
+===Evaluated XML (currently not supported)
   solr.get 'select', :params => {:wt => :xml}
-===JSON:
+===Raw XML
+  solr.get 'select', :params => {:wt => 'xml'}
+
+===Evaluated JSON
   solr.get 'select', :params => {:wt => :json}
+===Raw JSON
+  solr.get 'select', :params => {:wt => 'json'}
 
 ==Related Resources & Projects
 * {RSolr Google Group}[http://groups.google.com/group/rsolr] -- The RSolr discussion group

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -284,8 +284,12 @@ class RSolr::Client
 
     result = if request[:method] == :head
       ''
-    elsif respond_to? "evaluate_#{request[:params][:wt]}_response", true
-      send "evaluate_#{request[:params][:wt]}_response", request, response
+    elsif (wt = request[:params][:wt]).is_a?(Symbol)
+      if respond_to?(method = "evaluate_#{wt}_response", true)
+        send(method, request, response)
+      else
+        raise "The response cannot be evaluated: #{wt} not supported."
+      end
     else
       response[:body]
     end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -211,6 +211,12 @@ describe "RSolr::Client" do
       result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
       result.should == {:time=>"NOW"}
     end
+
+    it "should not evaluate ruby responses when the :wt is 'ruby'" do
+      body = '{:time=>"NOW"}'
+      result = client.adapt_response({:params=>{:wt=>'ruby'}}, {:status => 200, :body => body, :headers => {}})
+      result.should == body
+    end
     
     it 'should evaluate json responses when the :wt is :json' do
       body = '{"time": "NOW"}'
@@ -221,6 +227,12 @@ describe "RSolr::Client" do
         # ruby 1.8 without the JSON gem
         result.should == '{"time": "NOW"}'
       end
+    end
+
+    it "should try to evaluate the response when the :wt is a symbol" do
+      lambda {
+        client.adapt_response({:params=>{:wt => :a_symbol}}, {:status => 200, :body => '', :headers => {}})
+      }.should raise_error RuntimeError, /a_symbol/
     end
 
     it "ought raise a RSolr::Error::InvalidRubyResponse when the ruby is indeed frugged, or even fruggified" do


### PR DESCRIPTION
### HEAD requests don't have a response body to evaluate

The response of a HEAD request should never be evaluated. It's unnecessary and even causes an error with the new JSON evaluation because the empty string (`nil.to_s`) is invalid JSON syntax. I opted for an empty string as return value for two reasons:
1. `nil` is a singleton, so subsequent HEAD requests overwrite the request and response information of earlier HEAD requests.
2. The return value of a HEAD request shouldn't matter anyway, because it's not allowed to return a message-body in the response. An empty string seems to be in line with "raw" responses which also return strings.

This is not fully backwards compatible due to the changed return value, but nobody should have relied on that to begin with. This also fixes #74.
### Distinguish evaluated and raw responses by `wt' type

It seems to be convenient to associate evaluated and raw responses with different types of the `wt` parameter. A symbol means the response will be evaluated (or fails if unsupported), a string means the response will be returned in its raw form. This also fixes the documented behaviour of `:ruby` vs. `'ruby'` which currently doesn't work.

However, this also means that other documented behaviour (namely XML: `solr.get 'select', :params => {:wt => :xml}`) won't work anymore. Hence, this change is not backwards compatible.
