### PR TITLE
Fixed RSolr::Error to_s

### DIFF
--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -12,8 +12,8 @@ module RSolr::Error
         m << "\nError: #{details}\n" if details
       end
       p = "\nURI: #{request[:uri].to_s}"
-      p = "\nRequest Headers: #{request[:headers].inspect}" if request[:headers]
-      p = "\nRequest Data: #{request[:data].inspect}" if request[:data]
+      p << "\nRequest Headers: #{request[:headers].inspect}" if request[:headers]
+      p << "\nRequest Data: #{request[:data].inspect}" if request[:data]
       p << "\n"
       p << "\nBacktrace: " + self.backtrace[0..10].join("\n")
       m << p


### PR DESCRIPTION
We loose informations with the original implementation. This commit fix the issue. Thanks.
