### PR TITLE
Refactor response parsing: remove instance extend.

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -261,12 +261,7 @@ class RSolr::Client
     opts[:params]["rows"] = per_page
     build_request path, opts
   end
-  
-  #  A mixin for used by #adapt_response
-  module Context
-    attr_accessor :request, :response
-  end
-  
+
   # This method will evaluate the :body value
   # if the params[:uri].params[:wt] == :ruby
   # ... otherwise, the body is returned as is.
@@ -288,13 +283,15 @@ class RSolr::Client
       response[:body]
     end
 
-    result.extend Context
-    result.request, result.response = request, response
-    result.is_a?(Hash) ? result.extend(RSolr::Response) : result
+    if result.is_a?(Hash)
+      result = RSolr::HashWithResponse.new(request, response, result)
+    end
+
+    result
   end
-  
+
   protected
-  
+
   # converts the method name for the solr request handler path.
   def method_missing name, *args
     if name.to_s =~ /^paginated?_(.+)$/

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -233,12 +233,11 @@ describe "RSolr::Client" do
   
   context "indifferent access" do
     include ClientHelper
-    it "should raise a NoMethodError if the #with_indifferent_access extension isn't loaded" do
-      # TODO: Find a less implmentation-tied way to test this
-      expect_any_instance_of(Hash).to receive(:respond_to?).with(:with_indifferent_access).and_return(false)
+    it "should raise a RuntimeError if the #with_indifferent_access extension isn't loaded" do
+      hide_const("HashWithIndifferentAccess")
       body = "{'foo'=>'bar'}"
       result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
-      expect { result.with_indifferent_access }.to raise_error NoMethodError
+      expect { result.with_indifferent_access }.to raise_error RuntimeError
     end
 
     it "should provide indifferent access" do


### PR DESCRIPTION
Using per-instance `extend` calls is generally not a good pattern because it break's the Ruby VM's attempt to optimize by caching constants and method lookup. Using the per-instance `extend` style code here, for example, is definitely invalidating the global constant cache in the Ruby VM (and like the global/per-class method cache depending on the VM version.) You can confirm this by checking `RubyVM.stat[:global_constant_state]` on a VM that supports RubyVM stats (such as MRI 2.1.) This patch maintains the same behavior, but eliminates the usage of per-instance `extend` so that we don't invalidate the global constant cache harming performance for every app using RSolr after every Solr call.
