### PR TITLE
default_wt should be JSON not eval'd Ruby - for 2.x

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -153,14 +153,13 @@ Delete by array of queries
 == Response Formats
 The default response format is Ruby. When the :wt param is set to :ruby, the response is eval'd resulting in a Hash. You can get a raw response by setting the :wt to "ruby" - notice, the string -- not a symbol. RSolr will eval the Ruby string ONLY if the :wt value is :ruby. All other response formats are available as expected, :wt=>'xml' etc..
 
-===Evaluated Ruby (default)
+===Evaluated Ruby:
   solr.get 'select', :params => {:wt => :ruby} # notice :ruby is a Symbol
-===Raw Ruby
+===Raw Ruby:
   solr.get 'select', :params => {:wt => 'ruby'} # notice 'ruby' is a String
-
 ===XML:
   solr.get 'select', :params => {:wt => :xml}
-===JSON:
+===JSON (default):
   solr.get 'select', :params => {:wt => :json}
 
 ==Related Resources & Projects

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -327,7 +327,7 @@ class RSolr::Client
       if json.empty?
         nil
       else
-        JSON.parse json, :symbolize_names => true
+        JSON.parse json
       end
     rescue JSON::ParserError
       raise RSolr::Error::InvalidJsonResponse.new request, response

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -7,7 +7,7 @@ class RSolr::Client
 
   class << self
     def default_wt
-      @default_wt || :ruby
+      @default_wt || :json
     end
 
     def default_wt= value

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -323,7 +323,12 @@ class RSolr::Client
     return response[:body] unless defined? JSON
 
     begin
-      JSON.parse response[:body].to_s, :symbolize_names => true
+      json = response[:body].to_s
+      if json.empty?
+        nil
+      else
+        JSON.parse json, :symbolize_names => true
+      end
     rescue JSON::ParserError
       raise RSolr::Error::InvalidJsonResponse.new request, response
     end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -201,22 +201,22 @@ describe "RSolr::Client" do
   context "adapt_response" do
     include ClientHelper
     it 'should not try to evaluate ruby when the :qt is not :ruby' do
-      body = '{:time=>"NOW"}'
+      body = '{"time"=>"NOW"}'
       result = client.adapt_response({:params=>{}}, {:status => 200, :body => body, :headers => {}})
       expect(result).to eq(body)
     end
     
     it 'should evaluate ruby responses when the :wt is :ruby' do
-      body = '{:time=>"NOW"}'
+      body = '{"time"=>"NOW"}'
       result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
-      expect(result).to eq({:time=>"NOW"})
+      expect(result).to eq({"time"=>"NOW"})
     end
     
     it 'should evaluate json responses when the :wt is :json' do
       body = '{"time": "NOW"}'
       result = client.adapt_response({:params=>{:wt=>:json}}, {:status => 200, :body => body, :headers => {}})
       if defined? JSON
-        expect(result).to eq({:time=>"NOW"})
+        expect(result).to eq({"time"=>"NOW"})
       else
         # ruby 1.8 without the JSON gem
         expect(result).to eq('{"time": "NOW"}')

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -266,7 +266,7 @@ describe "RSolr::Client" do
         :data => "data",
         :headers => {}
       )
-      [/fq=0/, /fq=1/, /q=test/, /wt=ruby/].each do |pattern|
+      [/fq=0/, /fq=1/, /q=test/, /wt=json/].each do |pattern|
         expect(result[:query]).to match pattern
       end
       expect(result[:data]).to eq("data")
@@ -279,7 +279,7 @@ describe "RSolr::Client" do
         :data => {:q=>'test', :fq=>[0,1]},
         :headers => {}
       )
-      expect(result[:query]).to eq("wt=ruby")
+      expect(result[:query]).to eq("wt=json")
       [/fq=0/, /fq=1/, /q=test/].each do |pattern|
         expect(result[:data]).to match pattern
       end

--- a/spec/api/pagination_spec.rb
+++ b/spec/api/pagination_spec.rb
@@ -21,7 +21,7 @@ describe "RSolr::Pagination" do
         :params => {
           "rows" => 10,
           "start" => 0,
-          :wt => :ruby
+          :wt => :json
         }
       }))
       c.paginate 1, 10, "select"


### PR DESCRIPTION
For both performance and security reasons, it's much better to default to using JSON rather than using Ruby code and invoking Ruby's parse and interpreter to eval responses from Solr.