### PR TITLE
Add support for multiple nodes, so the :url option could be an array of URLs.

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -189,7 +189,6 @@ class RSolr::Client
   
   # 
   def execute request_context
-
     raw_response = connection.execute self, request_context
 
     while retry_503?(request_context, raw_response)
@@ -198,7 +197,10 @@ class RSolr::Client
       raw_response = connection.execute self, request_context
     end
 
-    adapt_response(request_context, raw_response) unless raw_response.nil?
+    unless raw_response.nil?
+      @failed_uris.clear unless @failed_uris.empty?
+      adapt_response(request_context, raw_response)
+    end
   end
 
   def try_another_node?(request_context)

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -65,7 +65,7 @@ class RSolr::Client
   # returns the uri proxy if present,
   # otherwise just the uri object.
   def base_uri
-    @proxy ? @proxy : @primary_uri
+    @proxy ? @proxy : @primary_uri.dup
   end
   
   # Create the get, post, and head methods

--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -19,7 +19,7 @@ class RSolr::Connection
       { :status => response.code.to_i,
         :headers => response.to_hash,
         :body => force_charset(response.body, charset) }
-    rescue Errno::ECONNREFUSED => e
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Net::OpenTimeout => e
       self.retry(client, request_context)
     rescue NoMethodError => e # catch the undefined closed? exception -- this is a confirmed ruby bug
       e.message == "undefined method `closed?' for nil:NilClass" ? self.retry(client, request_context) : raise(e)

--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -30,6 +30,10 @@ class RSolr::Connection
 
   # This returns a singleton of a Net::HTTP or Net::HTTP.Proxy request object.
   def http uri, proxy = nil, read_timeout = nil, open_timeout = nil
+    if @http and (@http.address != uri.host or @http.port != uri.port)
+      @http = nil
+    end
+
     @http ||= (
       http = if proxy
         proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
@@ -67,8 +71,6 @@ class RSolr::Connection
     unless client.try_another_node?(request_context)
       raise(Errno::ECONNREFUSED.new(request_context.inspect))
     end
-
-    @http = nil
 
     execute(client, request_context)
   end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -17,6 +17,18 @@ describe "RSolr::Client" do
       response.instance_variable_set("@read", true)
       response
     end
+
+    def request_context
+      {
+        :method => :post,
+        :params => {},
+        :data => nil,
+        :headers => {},
+        :path => '',
+        :uri => client.base_uri,
+        :retry_503 => 1
+      }
+    end
   end
 
   context "initialize" do
@@ -45,17 +57,7 @@ describe "RSolr::Client" do
 
   context "execute" do
     include ClientHelper
-    let :request_context do
-      {
-        :method => :post,
-        :params => {},
-        :data => nil,
-        :headers => {},
-        :path => '',
-        :uri => client.base_uri,
-        :retry_503 => 1
-      }
-    end
+
     it "should retry 503s if requested" do
       expect(client.connection).to receive(:execute).exactly(2).times.and_return(
         {:status => 503, :body => "{}", :headers => {'Retry-After' => 0}},

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -67,11 +67,11 @@ describe "RSolr::Client" do
     end
 
     it "should not modify stored URIs" do
-      client.instance_variable_get("@uri").map(&:to_s).should eq node_urls
+      client.instance_variable_get("@available_uris").map(&:to_s).should eq node_urls
 
       expect { client.execute request_context }.to raise_error(Errno::ECONNREFUSED)
 
-      client.instance_variable_get("@uri").map(&:to_s).should eq node_urls
+      client.instance_variable_get("@available_uris").map(&:to_s).should eq node_urls
     end
 
     it "should try all available nodes and then raise" do
@@ -85,7 +85,7 @@ describe "RSolr::Client" do
           http.stub(:request) do |request|
             "http://#{http.address}:#{http.port}/solr/".should eq node_urls[index]
             client.instance_variable_get("@primary_uri").to_s.should eq node_urls[index]
-            client.instance_variable_get("@failed_uri").size.should eq index
+            client.instance_variable_get("@failed_uris").size.should eq index
 
             index += 1
 
@@ -98,7 +98,7 @@ describe "RSolr::Client" do
       expect { client.execute request_context }.to raise_error(Errno::ECONNREFUSED)
 
       client.instance_variable_get("@primary_uri").to_s.should eq node_urls.first
-      client.instance_variable_get("@failed_uri").size.should eq 0
+      client.instance_variable_get("@failed_uris").size.should eq 0
     end
   end
 

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -59,8 +59,7 @@ describe "RSolr::Connection" do
   end
 
   context "connection refused" do
-    let(:client) { double.as_null_object }
-
+    let(:client) { RSolr.connect(:url => "http://localhost/some_uri") }
     let(:http) { double(Net::HTTP).as_null_object }
     let(:request_context) {
       {:uri => URI.parse("http://localhost/some_uri"), :method => :get, :open_timeout => 42}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 require File.expand_path('../../lib/rsolr', __FILE__)
+
+RSpec.configure do |config|
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+end


### PR DESCRIPTION
Allows to pass an array of URLs, and in case of `Errno::ECONNREFUSED` RSolr will now try another nodes (if available) before raising the error,