### PR TITLE
Allow multithreaded HTTP execution

### DIFF
--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -29,7 +29,7 @@ class RSolr::Connection
 
   # This returns a singleton of a Net::HTTP or Net::HTTP.Proxy request object.
   def http uri, proxy = nil, read_timeout = nil, open_timeout = nil
-    @http ||= (
+    Thread.current[:rsolr_http] ||= (
       http = if proxy
         proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
         Net::HTTP.Proxy(proxy.host, proxy.port, proxy_user, proxy_pass).new uri.host, uri.port

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require File.expand_path('../../lib/rsolr', __FILE__)
+
+RSpec.configure do |config|
+  config.after { Thread.current[:rsolr_http] = nil }
+end


### PR DESCRIPTION
Before this patch, if a person were to execute multiple queries multithreaded using the same `RSolr::Client`, `Net::HTTP` would throw errors like

    ~/.rbenv/versions/2.2.0/lib/ruby/2.2.0/net/protocol.rb:155:in `select': Bad file descriptor (Errno::EBADF)

This is because the same instance of `Net::HTTP` would be used concurrently, and an instance of `Net::HTTP` internally uses a stored IO object, so multiple threads would attempt to access it.

Example program which causes errors (I randomly get 3 types of errors):

```rb
require "rsolr"

Thread.abort_on_exception = true

client = RSolr.connect

10.times do
  Thread.new { client.get "select", params: {q: "*:*"} }
end

sleep 1
```