### PR TITLE
add license to gemspec per https://github.com/rsolr/rsolr/issues/81

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
                   "Naomi Dushay",
                   "\"shima\""]
   s.email       = ["goodieboy@gmail.com"]
+  s.license     = 'Apache-2.0'
   s.homepage    = "https://github.com/rsolr/rsolr"
   s.rubyforge_project = "rsolr"
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
See #81.   Idea is for license to show up on rubygems.