### PR TITLE
Use URI stdlib methods to escape URI

### DIFF
--- a/lib/rsolr/uri.rb
+++ b/lib/rsolr/uri.rb
@@ -3,7 +3,7 @@ require 'uri'
 module RSolr::Uri
   
   def create url
-    ::URI.parse url[-1] == ?/ ? url : "#{url}/"
+    ::URI.parse (url[-1] == '/' || URI.parse(url).query) ? url : "#{url}/"
   end
   
   # Returns a query string param pair as a string.

--- a/lib/rsolr/uri.rb
+++ b/lib/rsolr/uri.rb
@@ -34,20 +34,16 @@ module RSolr::Uri
     mapped.compact.join("&")
   end
   
+  # 2015-02  Deprecated: use URI.encode_www_form_component(s)
+  #
   # Performs URI escaping so that you can construct proper
   # query strings faster.  Use this rather than the cgi.rb
   # version since it's faster.
   # (Stolen from Rack).
-  # 
-  # 2015-02
-  # The Rack stuff is from 
   #  http://www.rubydoc.info/github/rack/rack/URI.encode_www_form_component
-  # We instead will rely on 
-  #  http://ruby-doc.org/stdlib-2.2.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component
-  #  which is from the Ruby stdlib.  Hence this method is deprecated.
   # @deprecated
   def escape_query_value(s)
-    warn "[DEPRECATION] `escape_query_value` is deprecated.  Please use `URI.encode_www_form_component` instead."
+    warn "[DEPRECATION] `RSolr::Uri.escape_query_value` is deprecated.  Use `URI.encode_www_form_component` instead."
     URI.encode_www_form_component(s)
 #    s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
 #      '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
@@ -59,12 +55,12 @@ module RSolr::Uri
   # @deprecated  as bytesize was only used by escape_query_value which is itself deprecated
   if ''.respond_to?(:bytesize)
     def bytesize(string)
-      warn "[DEPRECATION] `bytesize` is deprecated.  Use String.bytesize"
+      warn "[DEPRECATION] `RSolr::Uri.bytesize` is deprecated.  Use String.bytesize"
       string.bytesize
     end
   else
     def bytesize(string)
-      warn "[DEPRECATION] `bytesize` is deprecated.  Use String.size"
+      warn "[DEPRECATION] `RSolr::Uri.bytesize` is deprecated.  Use String.size"
       string.size
     end
   end

--- a/lib/rsolr/uri.rb
+++ b/lib/rsolr/uri.rb
@@ -59,12 +59,12 @@ module RSolr::Uri
   # @deprecated  as bytesize was only used by escape_query_value which is itself deprecated
   if ''.respond_to?(:bytesize)
     def bytesize(string)
-      warn "[DEPRECATION] `bytesize` is deprecated.  If you are using it, please provide use case to github.com/rsolr/rsolr as an issue."
+      warn "[DEPRECATION] `bytesize` is deprecated.  Use String.bytesize"
       string.bytesize
     end
   else
     def bytesize(string)
-      warn "[DEPRECATION] `bytesize` is deprecated.  If you are using it, please provide use case to github.com/rsolr/rsolr as an issue."
+      warn "[DEPRECATION] `bytesize` is deprecated.  Use String.size"
       string.size
     end
   end

--- a/lib/rsolr/uri.rb
+++ b/lib/rsolr/uri.rb
@@ -7,23 +7,12 @@ module RSolr::Uri
   end
   
   # Returns a query string param pair as a string.
-  # Both key and value are escaped.
-  def build_param(k,v, escape = true)
+  # Both key and value are URI escaped, unless third param is false
+  # @param [boolean] escape false if no URI escaping is to be performed.  Default true.
+  def build_param(k, v, escape = true)
     escape ? 
-      "#{escape_query_value(k)}=#{escape_query_value(v)}" :
+      "#{URI.encode_www_form_component(k)}=#{URI.encode_www_form_component(v)}" :
       "#{k}=#{v}"
-  end
-
-  # Return the bytesize of String; uses String#size under Ruby 1.8 and
-  # String#bytesize under 1.9.
-  if ''.respond_to?(:bytesize)
-    def bytesize(string)
-      string.bytesize
-    end
-  else
-    def bytesize(string)
-      string.size
-    end
   end
 
   # Creates a Solr based query string.
@@ -31,6 +20,8 @@ module RSolr::Uri
   #   params_to_solr(:q => 'query', :fq => ['a', 'b'])
   # is converted to:
   #   ?q=query&fq=a&fq=b
+  # @param [boolean] escape false if no URI escaping is to be performed.  Default true.
+  # @return [String] Solr query params as a String, suitable for use in a url
   def params_to_solr(params, escape = true)
     mapped = params.map do |k, v|
       next if v.to_s.empty?
@@ -47,12 +38,37 @@ module RSolr::Uri
   # query strings faster.  Use this rather than the cgi.rb
   # version since it's faster.
   # (Stolen from Rack).
+  # 
+  # 2015-02
+  # The Rack stuff is from 
+  #  http://www.rubydoc.info/github/rack/rack/URI.encode_www_form_component
+  # We instead will rely on 
+  #  http://ruby-doc.org/stdlib-2.2.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component
+  #  which is from the Ruby stdlib.  Hence this method is deprecated.
+  # @deprecated
   def escape_query_value(s)
-    s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
-      '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
-    }.tr(' ', '+')
+    warn "[DEPRECATION] `escape_query_value` is deprecated.  Please use `URI.encode_www_form_component` instead."
+    URI.encode_www_form_component(s)
+#    s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
+#      '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
+#    }.tr(' ', '+')
   end
-  
+
+  # Return the bytesize of String; uses String#size under Ruby 1.8 and
+  # String#bytesize under 1.9.
+  # @deprecated  as bytesize was only used by escape_query_value which is itself deprecated
+  if ''.respond_to?(:bytesize)
+    def bytesize(string)
+      warn "[DEPRECATION] `bytesize` is deprecated.  If you are using it, please provide use case to github.com/rsolr/rsolr as an issue."
+      string.bytesize
+    end
+  else
+    def bytesize(string)
+      warn "[DEPRECATION] `bytesize` is deprecated.  If you are using it, please provide use case to github.com/rsolr/rsolr as an issue."
+      string.size
+    end
+  end
+
   extend self
   
 end

--- a/spec/api/uri_spec.rb
+++ b/spec/api/uri_spec.rb
@@ -1,20 +1,77 @@
 require 'spec_helper'
 describe "RSolr::Uri" do
   
-  context "class-level methods" do
-    
-    let(:uri){ RSolr::Uri }
-    
-    it "should return a URI object with a trailing slash" do
-      u = uri.create 'http://apache.org'
-      expect(u.path[0]).to eq(?/)
-    end
+  let(:uri) { RSolr::Uri }
   
-    it "should return the bytesize of a string" do
+  context '.create' do
+    it "returns a URI object" do
+      u = uri.create 'http://apache.org'
+      expect(u).to be_a_kind_of URI
+    end
+    it "calls URI.parse" do
+      expect(URI).to receive(:parse)
+      u = uri.create 'http://apache.org'
+    end
+    it "adds a trailing slash after host if there is none" do
+      u = uri.create 'http://apache.org'
+      u_str = u.to_s
+      size = u_str.size
+      expect(u_str[size - 1]).to eq '/'
+    end
+    it "does not add trailing slash after host if there already is one" do
+      u = uri.create 'http://apache.org/'
+      u_str = u.to_s
+      size = u_str.size
+      expect(u_str[size - 2, 2]).to eq 'g/'
+    end
+    it "adds a trailing slash after path if there is none" do
+      u = uri.create 'http://apache.org/lucene'
+      u_str = u.to_s
+      size = u_str.size
+      expect(u_str[size - 1]).to eq '/'
+    end
+    it "does not add trailing slash after path if there already is one" do
+      u = uri.create 'http://apache.org/lucene/'
+      u_str = u.to_s
+      size = u_str.size
+      expect(u_str[size - 2, 2]).to eq 'e/'
+    end
+    it "does not add trailing slash if there are query params" do
+      u = uri.create 'http://apache.org?foo=bar'
+      u_str = u.to_s
+      size = u_str.size
+      expect(u_str[size - 1]).not_to eq '/'
+    end
+  end
+
+  context '.build_param' do
+    it "calls escape_query_value by default" do
+      expect(RSolr::Uri).to receive(:escape_query_value).twice
+      uri.build_param("foo", "bar")
+    end
+    it "calls escape_query_value if escape arg = true" do
+      expect(RSolr::Uri).to receive(:escape_query_value).twice
+      uri.build_param("foo", "bar", true)
+    end
+    it "doesn't call escape_query_value if escape arg = false" do
+      expect(RSolr::Uri).not_to receive(:escape_query_value)
+      uri.build_param("foo", "bar", false)
+    end
+  end
+
+  context '.bytesize' do
+    it "calls .bytesize for String" do
+      str = "testing"
+      expect(str).to receive(:bytesize)
+      uri.bytesize(str)
+    end
+    it "returns the size of a String" do
       expect(uri.bytesize("test")).to eq(4)
     end
+  end
   
-    it "should convert a solr query string from a hash w/o a starting ?" do
+  context '.params_to_solr' do
+    it "converts Hash to Solr query string w/o a starting ?" do
       hash = {:q => "gold", :fq => ["mode:one", "level:2"]}
       query = uri.params_to_solr hash
       expect(query[0]).not_to eq(??)
@@ -23,48 +80,44 @@ describe "RSolr::Uri" do
       end
       expect(query.split('&').size).to eq(3)
     end
-    
-    context "escape_query_value" do
-      
-      it 'should escape &' do
-        expect(uri.params_to_solr(:fq => "&")).to eq('fq=%26')
-      end
-
-      it 'should convert spaces to +' do
-        expect(uri.params_to_solr(:fq => "me and you")).to eq('fq=me+and+you')
-      end
-
-      it 'should escape comlex queries, part 1' do
-        my_params = {'fq' => '{!raw f=field_name}crazy+\"field+value'}
-        expected = 'fq=%7B%21raw+f%3Dfield_name%7Dcrazy%2B%5C%22field%2Bvalue'
-        expect(uri.params_to_solr(my_params)).to eq(expected)
-      end
-
-      it 'should escape complex queries, part 2' do
-        my_params = {'q' => '+popularity:[10 TO *] +section:0'}
-        expected = 'q=%2Bpopularity%3A%5B10+TO+%2A%5D+%2Bsection%3A0'
-        expect(uri.params_to_solr(my_params)).to eq(expected)
-      end
-      
-      it 'should escape properly' do
-        expect(uri.escape_query_value('+')).to eq('%2B')
-        expect(uri.escape_query_value('This is a test')).to eq('This+is+a+test')
-        expect(uri.escape_query_value('<>/\\')).to eq('%3C%3E%2F%5C')
-        expect(uri.escape_query_value('"')).to eq('%22')
-        expect(uri.escape_query_value(':')).to eq('%3A')
-      end
-
-      it 'should escape brackets' do
-        expect(uri.escape_query_value('{')).to eq('%7B')
-        expect(uri.escape_query_value('}')).to eq('%7D')
-      end
-
-      it 'should escape exclamation marks!' do
-        expect(uri.escape_query_value('!')).to eq('%21')
-      end
-      
+    it 'should escape &' do
+      expect(uri.params_to_solr(:fq => "&")).to eq('fq=%26')
     end
-    
+
+    it 'should convert spaces to +' do
+      expect(uri.params_to_solr(:fq => "me and you")).to eq('fq=me+and+you')
+    end
+
+    it 'should escape complex queries, part 1' do
+      my_params = {'fq' => '{!raw f=field_name}crazy+\"field+value'}
+      expected = 'fq=%7B%21raw+f%3Dfield_name%7Dcrazy%2B%5C%22field%2Bvalue'
+      expect(uri.params_to_solr(my_params)).to eq(expected)
+    end
+
+    it 'should escape complex queries, part 2' do
+      my_params = {'q' => '+popularity:[10 TO *] +section:0'}
+      expected = 'q=%2Bpopularity%3A%5B10+TO+%2A%5D+%2Bsection%3A0'
+      expect(uri.params_to_solr(my_params)).to eq(expected)
+    end
+  end
+  
+  context ".escape_query_value" do
+    it 'should escape properly' do
+      expect(uri.escape_query_value('+')).to eq('%2B')
+      expect(uri.escape_query_value('This is a test')).to eq('This+is+a+test')
+      expect(uri.escape_query_value('<>/\\')).to eq('%3C%3E%2F%5C')
+      expect(uri.escape_query_value('"')).to eq('%22')
+      expect(uri.escape_query_value(':')).to eq('%3A')
+    end
+
+    it 'should escape brackets' do
+      expect(uri.escape_query_value('{')).to eq('%7B')
+      expect(uri.escape_query_value('}')).to eq('%7D')
+    end
+
+    it 'should escape exclamation marks!' do
+      expect(uri.escape_query_value('!')).to eq('%21')
+    end
   end
   
 end

--- a/spec/api/uri_spec.rb
+++ b/spec/api/uri_spec.rb
@@ -44,21 +44,6 @@ describe "RSolr::Uri" do
     end
   end
 
-  context '.build_param' do
-    it "calls URI.encode_www_form_component by default" do
-      expect(URI).to receive(:encode_www_form_component).twice
-      uri.build_param("foo", "bar")
-    end
-    it "calls URI.encode_www_form_component if escape arg = true" do
-      expect(URI).to receive(:encode_www_form_component).twice
-      uri.build_param("foo", "bar", true)
-    end
-    it "doesn't call URI.encode_www_form_component if escape arg = false" do
-      expect(URI).not_to receive(:encode_www_form_component)
-      uri.build_param("foo", "bar", false)
-    end
-  end
-
   context '.params_to_solr' do
     it "converts Hash to Solr query string w/o a starting ?" do
       hash = {:q => "gold", :fq => ["mode:one", "level:2"]}
@@ -91,6 +76,22 @@ describe "RSolr::Uri" do
   end
   
 =begin
+  # deprecated
+  context '.build_param' do
+    it "calls URI.encode_www_form_component by default" do
+      expect(URI).to receive(:encode_www_form_component).twice
+      uri.build_param("foo", "bar")
+    end
+    it "calls URI.encode_www_form_component if escape arg = true" do
+      expect(URI).to receive(:encode_www_form_component).twice
+      uri.build_param("foo", "bar", true)
+    end
+    it "doesn't call URI.encode_www_form_component if escape arg = false" do
+      expect(URI).not_to receive(:encode_www_form_component)
+      uri.build_param("foo", "bar", false)
+    end
+  end
+
   # deprecated
   context ".escape_query_value" do
     it 'should escape properly' do

--- a/spec/api/uri_spec.rb
+++ b/spec/api/uri_spec.rb
@@ -9,7 +9,7 @@ describe "RSolr::Uri" do
       expect(u).to be_a_kind_of URI
     end
     it "calls URI.parse" do
-      expect(URI).to receive(:parse)
+      expect(URI).to receive(:parse).twice.and_call_original
       u = uri.create 'http://apache.org'
     end
     it "adds a trailing slash after host if there is none" do

--- a/spec/api/uri_spec.rb
+++ b/spec/api/uri_spec.rb
@@ -45,31 +45,20 @@ describe "RSolr::Uri" do
   end
 
   context '.build_param' do
-    it "calls escape_query_value by default" do
-      expect(RSolr::Uri).to receive(:escape_query_value).twice
+    it "calls URI.encode_www_form_component by default" do
+      expect(URI).to receive(:encode_www_form_component).twice
       uri.build_param("foo", "bar")
     end
-    it "calls escape_query_value if escape arg = true" do
-      expect(RSolr::Uri).to receive(:escape_query_value).twice
+    it "calls URI.encode_www_form_component if escape arg = true" do
+      expect(URI).to receive(:encode_www_form_component).twice
       uri.build_param("foo", "bar", true)
     end
-    it "doesn't call escape_query_value if escape arg = false" do
-      expect(RSolr::Uri).not_to receive(:escape_query_value)
+    it "doesn't call URI.encode_www_form_component if escape arg = false" do
+      expect(URI).not_to receive(:encode_www_form_component)
       uri.build_param("foo", "bar", false)
     end
   end
 
-  context '.bytesize' do
-    it "calls .bytesize for String" do
-      str = "testing"
-      expect(str).to receive(:bytesize)
-      uri.bytesize(str)
-    end
-    it "returns the size of a String" do
-      expect(uri.bytesize("test")).to eq(4)
-    end
-  end
-  
   context '.params_to_solr' do
     it "converts Hash to Solr query string w/o a starting ?" do
       hash = {:q => "gold", :fq => ["mode:one", "level:2"]}
@@ -96,11 +85,13 @@ describe "RSolr::Uri" do
 
     it 'should escape complex queries, part 2' do
       my_params = {'q' => '+popularity:[10 TO *] +section:0'}
-      expected = 'q=%2Bpopularity%3A%5B10+TO+%2A%5D+%2Bsection%3A0'
+      expected = 'q=%2Bpopularity%3A%5B10+TO+*%5D+%2Bsection%3A0'
       expect(uri.params_to_solr(my_params)).to eq(expected)
     end
   end
   
+=begin
+  # deprecated
   context ".escape_query_value" do
     it 'should escape properly' do
       expect(uri.escape_query_value('+')).to eq('%2B')
@@ -120,4 +111,17 @@ describe "RSolr::Uri" do
     end
   end
   
+  # deprecated
+  context '.bytesize' do
+    it "calls .bytesize for String" do
+      str = "testing"
+      expect(str).to receive(:bytesize)
+      uri.bytesize(str)
+    end
+    it "returns the size of a String" do
+      expect(uri.bytesize("test")).to eq(4)
+    end
+  end
+=end
+
 end


### PR DESCRIPTION
use URI.encode_www_form_component instead of escape_query_value and mark old way and bytesize in RSolr::Uri class as deprecated.

Addresses #94 