### PR TITLE
Correct Solr escaping

### DIFF
--- a/lib/rsolr.rb
+++ b/lib/rsolr.rb
@@ -8,7 +8,19 @@ module RSolr
     Client.new driver.new, opts
   end
   
-  # RSolr.escape
+  # RSolr.escape, which is deprecated as of 2015-02
   extend Char
+  
+  # backslash escape characters that have special meaning to Solr query parser
+  # per http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
+  #  + - & | ! ( ) { } [ ] ^ " ~ * ? : \ /
+  # see also http://svn.apache.org/repos/asf/lucene/dev/tags/lucene_solr_4_9_1/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
+  #   escapeQueryChars method
+  # @return [String] str with special chars preceded by a backslash
+  def self.solr_escape(str)
+    # note that the gsub will parse the escaped backslashes, as will the ruby code sending the query to Solr 
+    # so the result sent to Solr is ultimately a single backslash in front of the particular character 
+    str.gsub(/([+\-&|!\(\)\{\}\[\]\^"~\*\?:\\\/])/, '\\\\\1')
+  end
   
 end

--- a/lib/rsolr/char.rb
+++ b/lib/rsolr/char.rb
@@ -3,7 +3,9 @@ module RSolr::Char
   
   # backslash everything
   # that isn't a word character
+  # @deprecated - this is incorrect Solr escaping
   def escape value
+    warn "[DEPRECATION] `RSolr.escape` is deprecated (and incorrect).  Use `Rsolr.solr_escape` instead."
     value.gsub(/(\W)/, '\\\\\1')
   end
   

--- a/spec/api/char_spec.rb
+++ b/spec/api/char_spec.rb
@@ -3,6 +3,10 @@ describe "RSolr::Char" do
   
   let(:char){Object.new.extend RSolr::Char}
   
+  # deprecated as of 2015-02, as it is incorrect Solr escaping.
+  #  instead, use RSolr.solr_escape
+  #  commented out as it gives a mess of deprecation warnings
+=begin  
   it 'should escape everything that is not a word with \\' do
     (0..255).each do |ascii|
       chr = ascii.chr
@@ -14,5 +18,5 @@ describe "RSolr::Char" do
       end
     end
   end
-  
+=end  
 end

--- a/spec/api/rsolr_spec.rb
+++ b/spec/api/rsolr_spec.rb
@@ -4,16 +4,36 @@ describe "RSolr" do
   it "has a version that can be read via #version or VERSION" do
     expect(RSolr.version).to eq(RSolr::VERSION)
   end
-  
-  it "can escape" do
-    expect(RSolr).to be_a(RSolr::Char)
-    expect(RSolr.escape("this string")).to eq("this\\ string")
-  end
-  
+
   context "connect" do
     it "should return a RSolr::Client instance" do
       expect(RSolr.connect).to be_a(RSolr::Client)
     end
   end
+  
+  context '.solr_escape' do
+    it "adds backslash to Solr query syntax chars" do
+      # per http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
+      special_chars = [ "+", "-", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", '"', "~", "*", "?", ":", "\\", "/" ]
+      escaped_str = RSolr.solr_escape("aa#{special_chars.join('aa')}aa")
+      special_chars.each { |c|
+        # note that the ruby code sending the query to Solr will un-escape the backslashes
+        # so the result sent to Solr is ultimately a single backslash in front of the particular character 
+        expect(escaped_str).to match "\\#{c}"
+      }
+    end
+    it "leaves other chars alone" do
+      str = "nothing to see here; let's move along people."
+      expect(RSolr.solr_escape(str)).to eq str
+    end
+  end
+
+  # deprecated as of 2015-02
+=begin
+  it "can escape" do
+    expect(RSolr).to be_a(RSolr::Char)
+    expect(RSolr.escape("this string")).to eq("this\\ string")
+  end
+=end
   
 end

--- a/spec/api/uri_spec.rb
+++ b/spec/api/uri_spec.rb
@@ -54,7 +54,7 @@ describe "RSolr::Uri" do
       end
       expect(query.split('&').size).to eq(3)
     end
-    it 'should escape &' do
+    it 'should URL escape &' do
       expect(uri.params_to_solr(:fq => "&")).to eq('fq=%26')
     end
 
@@ -62,13 +62,13 @@ describe "RSolr::Uri" do
       expect(uri.params_to_solr(:fq => "me and you")).to eq('fq=me+and+you')
     end
 
-    it 'should escape complex queries, part 1' do
+    it 'should URL escape complex queries, part 1' do
       my_params = {'fq' => '{!raw f=field_name}crazy+\"field+value'}
       expected = 'fq=%7B%21raw+f%3Dfield_name%7Dcrazy%2B%5C%22field%2Bvalue'
       expect(uri.params_to_solr(my_params)).to eq(expected)
     end
 
-    it 'should escape complex queries, part 2' do
+    it 'should URL escape complex queries, part 2' do
       my_params = {'q' => '+popularity:[10 TO *] +section:0'}
       expected = 'q=%2Bpopularity%3A%5B10+TO+*%5D+%2Bsection%3A0'
       expect(uri.params_to_solr(my_params)).to eq(expected)


### PR DESCRIPTION
The Solr escaping currently in RSolr.escape is incorrect - it escapes too many characters and search results can be different with the incorrect escaping than with correct escaping. (e.g. inappropriately Solr escaped spaces can affect search results).

I have added an RSolr.solr_escape method that is correct.  

The only controversial thing here is that I put in a deprecation warning for RSolr.escape.  Since replacing the code in the method will be non-backwards compatible, it seems safer to add a new method.   Also, since the method is incorrect, I think we should have a plan to remove the incorrect method and therefore need to warn users.

Note that RSolr.escape is called by
lib/blacklight/solr/search_builder.rb
251:          "#{prefix}#{facet_field}:#{RSolr.escape(value)}"
253:          "#{prefix}#{facet_field}:#{RSolr.escape(value.to_time.utc.strftime("%Y-%m-%dT%H:%M:%SZ"))}"
257:          "#{prefix}#{facet_field}:#{RSolr.escape(value.to_s)}"
