### PR TITLE
Make json parse keys as strings to be consistent with ruby parsing

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -326,7 +326,7 @@ class RSolr::Client
     return response[:body] unless defined? JSON
 
     begin
-      JSON.parse response[:body].to_s, :symbolize_names => true
+      JSON.parse response[:body].to_s
     rescue JSON::ParserError
       raise RSolr::Error::InvalidJsonResponse.new request, response
     end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -201,22 +201,22 @@ describe "RSolr::Client" do
   context "adapt_response" do
     include ClientHelper
     it 'should not try to evaluate ruby when the :qt is not :ruby' do
-      body = '{:time=>"NOW"}'
+      body = '{"time"=>"NOW"}'
       result = client.adapt_response({:params=>{}}, {:status => 200, :body => body, :headers => {}})
       expect(result).to eq(body)
     end
     
     it 'should evaluate ruby responses when the :wt is :ruby' do
-      body = '{:time=>"NOW"}'
+      body = '{"time"=>"NOW"}'
       result = client.adapt_response({:params=>{:wt=>:ruby}}, {:status => 200, :body => body, :headers => {}})
-      expect(result).to eq({:time=>"NOW"})
+      expect(result).to eq({"time"=>"NOW"})
     end
     
     it 'should evaluate json responses when the :wt is :json' do
       body = '{"time": "NOW"}'
       result = client.adapt_response({:params=>{:wt=>:json}}, {:status => 200, :body => body, :headers => {}})
       if defined? JSON
-        expect(result).to eq({:time=>"NOW"})
+        expect(result).to eq({"time"=>"NOW"})
       else
         # ruby 1.8 without the JSON gem
         expect(result).to eq('{"time": "NOW"}')


### PR DESCRIPTION
This cherry-picks out the @jcoleman 's commit from PR #84, hopefully to be merged ahead of 2.x. Currently applications built on rsolr are not easily able to utilize the json parsing because the keys are symbols and not strings like the ruby parser. 