### PR TITLE
Make update request handler configurable

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -15,7 +15,7 @@ class RSolr::Client
     end
   end
   
-  attr_reader :connection, :uri, :proxy, :options
+  attr_reader :connection, :uri, :proxy, :options, :update_path
   
   def initialize connection, options = {}
     @proxy = @uri = nil
@@ -30,6 +30,7 @@ class RSolr::Client
         @proxy = RSolr::Uri.create proxy_url if proxy_url
       end
     end
+    @update_path = options.fetch(:update_path, 'update')
     @options = options
   end
   
@@ -79,7 +80,7 @@ class RSolr::Client
   def update opts = {}
     opts[:headers] ||= {}
     opts[:headers]['Content-Type'] ||= 'text/xml'
-    post 'update', opts
+    post opts.fetch(:path, update_path), opts
   end
   
   # 

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -14,6 +14,16 @@ describe "RSolr::Client" do
     it "should accept whatevs and set it as the @connection" do
       expect(RSolr::Client.new(:whatevs).connection).to eq(:whatevs)
     end
+    
+    it "should use :update_path from options" do
+      client = RSolr::Client.new(:whatevs, { update_path: 'update_test' })
+      expect(client.update_path).to eql('update_test')
+    end
+    
+    it "should use 'update' for update_path by default" do
+      client = RSolr::Client.new(:whatevs)
+      expect(client.update_path).to eql('update')
+    end
   end
   
   context "send_and_receive" do
@@ -130,6 +140,18 @@ describe "RSolr::Client" do
             :headers => {"Content-Type"=>"text/xml"}
           )
       client.update(:data => "<optimize/>")
+    end
+
+    it "should use #update_path" do
+      expect(client).to receive(:post).with('update_test', any_args)
+      expect(client).to receive(:update_path).and_return('update_test')
+      client.update({})
+    end
+    
+    it "should use path from opts" do
+      expect(client).to receive(:post).with('update_opts', any_args)
+      allow(client).to receive(:update_path).and_return('update_test')
+      client.update({path: 'update_opts'})
     end
   end
   


### PR DESCRIPTION
Adds support to use other than the default '/update' and '/select' request handlers in Solr.
