### PR TITLE
more helpful error messages when response contains msg key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 1.8.7
   - jruby-19mode
 
+before_install:
+  - gem update --system
+  - gem update bundler
+
 notifications:
   irc: "irc.freenode.org#blacklight"
   email:

--- a/spec/integration/solr5_spec.rb
+++ b/spec/integration/solr5_spec.rb
@@ -19,7 +19,7 @@ describe "Solr basic_configs" do
       end
 
       it "should not have a body" do
-        expect(subject.head('admin/ping')).to be_nil
+        expect(subject.head('admin/ping')).to eq({})
       end
     end
   end


### PR DESCRIPTION
As mentioned in [Blacklight issue #1377](https://github.com/projectblacklight/blacklight/issues/1377) - more useful error messages when error contains a msg key. Note I spent a little bit of time refactoring the tests in the error spec, hope this is okay.