### PR TITLE
if no proxy was passed, force the use of no proxy by explicitly passing nil to Net::HTTP

### DIFF
--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -33,6 +33,10 @@ class RSolr::Connection
       http = if proxy
         proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
         Net::HTTP.Proxy(proxy.host, proxy.port, proxy_user, proxy_pass).new uri.host, uri.port
+      elsif proxy == false
+        # If explicitly passing in false, make sure we set proxy_addr to nil
+        # to tell Net::HTTP to *not* use the environment proxy variables.
+        Net::HTTP.new uri.host, uri.port, nil
       else
         Net::HTTP.new uri.host, uri.port
       end


### PR DESCRIPTION
Without this change, it's impossible to make requests without using a proxy if the environment you're running on has the `HTTP_PROXY` class of variables set, since `Net::HTTP` will check those variables and use the proxy set by them if we don't explicitly pass `nil` as the `proxy_addr` param.