### PR TITLE
Don't use duck-typing to format values for solr

### DIFF
--- a/lib/rsolr/xml.rb
+++ b/lib/rsolr/xml.rb
@@ -51,10 +51,13 @@ module RSolr::Xml
     private
 
     def format_value(v)
-      if v.is_a?(Date) && !v.is_a?(DateTime)
-        Time.utc(v.year, v.mon, v.mday).iso8601
-      elsif v.respond_to?(:to_time) && v.to_time
+      case v
+      when Time
+        v.getutc.iso8601
+      when DateTime
         v.to_time.getutc.iso8601
+      when Date
+        Time.utc(v.year, v.mon, v.mday).iso8601
       else
         v.to_s
       end


### PR DESCRIPTION
Rails helpfully monkey-patches String to include #to_time, and unfortunately
will throw an ArgumentError if the String isn't time-y. Also, unfortunately, if
the string is vaguely time-like (e.g. "2016"), Rails will provide a time value
(and we certainly don't want to transform every integer into a
iso8601-formatted string..)