### PR TITLE
Fix deprecation warnings

### DIFF
--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -351,7 +351,7 @@ describe "RSolr::Client" do
         :data => {:q=>'test', :fq=>[0,1]},
         :headers => {}
       )
-      result[:uri].to_s.should match /^http:\/\/localhost:9999\/solr\//
+      expect(result[:uri].to_s).to match /^http:\/\/localhost:9999\/solr\//
     end 
   end
 end

--- a/spec/api/connection_spec.rb
+++ b/spec/api/connection_spec.rb
@@ -21,12 +21,12 @@ describe "RSolr::Connection" do
 
     it "raises a custom exception" do
       http_stub = double("Net:HTTP")
-      http_stub.stub(:request){ raise(Errno::ECONNREFUSED.new) }
+      allow(http_stub).to receive(:request).and_raise(Errno::ECONNREFUSED)
 
-      subject.stub(:setup_raw_request){ http_stub }
-      subject.stub(:http){ Net::HTTP.new("localhost", 80) }
+      allow(subject).to receive(:setup_raw_request) { http_stub }
+      allow(subject).to receive(:http) { Net::HTTP.new("localhost", 80) }
 
-      lambda{ subject.execute(nil,{}) }.should raise_error(RSolr::Error::ConnectionRefused)
+      expect { subject.execute(nil, {}) }.to raise_error(RSolr::Error::ConnectionRefused)
     end
   end
 


### PR DESCRIPTION
Fix the following deprecation warnings.

```sh
$ bundle exec rake

(snip)

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead.

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead.

2 deprecation warnings total
```

Thanks.
