### PR TITLE
Better SolrCloud support (allow the :url option to be an array of URLs).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "builder", ">= 2.1.2"
+gem "byebug"
 
 if defined? RUBY_VERSION and RUBY_VERSION < "1.9"
   gem 'nokogiri', "< 1.6"

--- a/lib/rsolr/connection.rb
+++ b/lib/rsolr/connection.rb
@@ -13,14 +13,18 @@ class RSolr::Connection
     request.body = request_context[:data] if request_context[:method] == :post and request_context[:data]
     begin
       response = h.request request
-      charset = response.type_params["charset"]
-      {:status => response.code.to_i, :headers => response.to_hash, :body => force_charset(response.body, charset)}
+
+      { :status => response.code.to_i,
+        :headers => response.to_hash,
+        :body => force_charset(response.body, response.type_params["charset"]) }
     rescue Errno::ECONNREFUSED
-      raise RSolr::Error::ConnectionRefused, request_context.inspect
+      self.retry(RSolr::Error::ConnectionRefused, client, request_context)
+    rescue Errno::EHOSTUNREACH, Net::OpenTimeout, Net::ReadTimeout => e
+      self.retry(e, client, request_context)
     # catch the undefined closed? exception -- this is a confirmed ruby bug
     rescue NoMethodError => e
       e.message == "undefined method `closed?' for nil:NilClass" ?
-        raise(RSolr::Error::ConnectionRefused, request_context.inspect) :
+        self.retry(RSolr::Error::ConnectionRefused, client, request_context) :
         raise(e)
     end
   end
@@ -28,21 +32,27 @@ class RSolr::Connection
   protected
 
   # This returns a singleton of a Net::HTTP or Net::HTTP.Proxy request object.
-  def http uri, proxy = nil, read_timeout = nil, open_timeout = nil
-    http = if proxy
-      proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy.userinfo
-      Net::HTTP.Proxy(proxy.host, proxy.port, proxy_user, proxy_pass).new uri.host, uri.port
-    elsif proxy == false
-      # If explicitly passing in false, make sure we set proxy_addr to nil
-      # to tell Net::HTTP to *not* use the environment proxy variables.
-      Net::HTTP.new uri.host, uri.port, nil
-    else
-      Net::HTTP.new uri.host, uri.port
+  def http(uri, proxy = nil, read_timeout = nil, open_timeout = nil)
+    if @http and (@http.address != uri.host or @http.port != uri.port)
+      @http = nil
     end
-    http.use_ssl = uri.port == 443 || uri.instance_of?(URI::HTTPS)
-    http.read_timeout = read_timeout if read_timeout
-    http.open_timeout = open_timeout if open_timeout
-    http
+
+    @http ||= begin
+      http = if proxy
+        proxy_user, proxy_pass = proxy.userinfo && proxy.userinfo.split(/:/)
+        Net::HTTP.Proxy(proxy.host, proxy.port, proxy_user, proxy_pass).new uri.host, uri.port
+      elsif proxy == false
+        # If explicitly passing in false, make sure we set proxy_addr to nil
+        # to tell Net::HTTP to *not* use the environment proxy variables.
+        Net::HTTP.new uri.host, uri.port, nil
+      else
+        Net::HTTP.new uri.host, uri.port
+      end
+      http.use_ssl = uri.port == 443 || uri.instance_of?(URI::HTTPS)
+      http.read_timeout = read_timeout if read_timeout
+      http.open_timeout = open_timeout if open_timeout
+      http
+    end
   end
 
   #
@@ -62,6 +72,14 @@ class RSolr::Connection
     raw_request.initialize_http_header headers
     raw_request.basic_auth(request_context[:uri].user, request_context[:uri].password) if request_context[:uri].user && request_context[:uri].password
     raw_request
+  end
+
+  def retry(e, client, request_context)
+    unless client.try_another_node?(request_context)
+      raise(e, request_context.inspect)
+    end
+
+    execute(client, request_context)
   end
 
   private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 require 'rsolr'
 require 'rspec'
+require 'byebug'
 
 FIXTURES_DIR = File.expand_path("fixtures", File.dirname(__FILE__))
 
 RSpec.configure do |c|
-
+  c.filter_run :focus => true
+  c.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
So with a SolrCloud cluster it will now be possible to reboot/shut down some nodes with zero downtime for the search service.

The algorithm is quite simple, here's an example with 3 URLs in config:
* RSolr sends a request
* URL1 is selected
* request failed
* URL1 is blacklisted, URL2 selected
* Rsolr retries the request
* request failed
* URL2 is blacklisted, URL3 selected
* Rsolr retries the request
* request failed
* the ConnectionRefused error is raised
* the list of blacklisted URLs if cleared

* RSolr sends a request
* URL1 is selected
* request failed
* URL1 is blacklisted, URL2 selected
* Rsolr retries the request
* request succeeded
* the list of blacklisted URLs if cleared

* RSolr sends a request
* URL2 is selected
* request failed
* URL2 is blacklisted, URL1 selected
* Rsolr retries the request
* request failed
* URL1 is blacklisted, URL3 selected
* Rsolr retries the request
* request succeeded
* the list of blacklisted URLs if cleared