### PR TITLE
Ensuring indexing sanitizes control characters

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -3,6 +3,8 @@ begin
 rescue LoadError
 end
 
+require 'rsolr/sanitize_control_characters_for_indexing'
+
 class RSolr::Client
 
   class << self
@@ -101,7 +103,8 @@ class RSolr::Client
   #
   def add doc, opts = {}
     add_attributes = opts.delete :add_attributes
-    update opts.merge(:data => xml.add(doc, add_attributes))
+    sanitized_doc = RSolr::SanitizeControlCharactersForIndexing.sanitize_document(doc)
+    update opts.merge(:data => xml.add(sanitized_doc, add_attributes))
   end
 
   # send "commit" xml with opts

--- a/lib/rsolr/sanitize_control_characters_for_indexing.rb
+++ b/lib/rsolr/sanitize_control_characters_for_indexing.rb
@@ -1,0 +1,47 @@
+module RSolr
+  # Responsible for exposing a sanitization method for control characters when indexing Solr.
+  #
+  # Without these changes we end up with an exception of the following form:
+  #
+  # ```ruby
+  #   RSolr::Error::Http - 400 Bad Request
+  #   Error: {'responseHeader'=>{'status'=>400,'QTime'=>31},'error'=>{'msg'=>'Illegal character ((CTRL-CHAR, code 12))
+  #     at [row,col {unknown-source}]: [1,70]','code'=>400}}
+  # ```
+  module SanitizeControlCharactersForIndexing
+    # @api private
+    #
+    # Responsible for stripping control characters
+    #
+    # @param doc [Hash] the document to sanitize
+    # @return [Hash] sanitized document
+    def self.sanitize_document(doc)
+      sanitized_doc = {}
+      doc.each_pair do |key, value|
+        sanitized_doc[key] = sanitize_value(value)
+      end
+      sanitized_doc
+    end
+
+    # @api private
+    def self.sanitize_value(value)
+      case value
+      when Hash
+        sanitize_document(value)
+      when Array
+        value.map { |v| sanitize_value(v) }
+      when String
+        value.gsub(/[[:cntrl:]]/) do |character|
+          case character
+          when "\t", "\n", "\r"
+            character
+          else
+            " "
+          end
+        end
+      else
+        value
+      end
+    end
+  end
+end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -123,6 +123,7 @@ describe "RSolr::Client" do
   context "add" do
     include ClientHelper
     it "should send xml to the connection's #post method" do
+      expect(RSolr::SanitizeControlCharactersForIndexing).to receive(:sanitize_document).and_call_original
       expect(client.connection).to receive(:execute).
         with(
           client, hash_including({
@@ -344,7 +345,7 @@ describe "RSolr::Client" do
         expect(subject[:headers]).to eq({"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"})
       end
     end
-   
+
     it "should properly handle proxy configuration" do
       result = client_with_proxy.build_request('select',
         :method => :post,
@@ -352,6 +353,6 @@ describe "RSolr::Client" do
         :headers => {}
       )
       expect(result[:uri].to_s).to match /^http:\/\/localhost:9999\/solr\//
-    end 
+    end
   end
 end

--- a/spec/api/sanitize_control_characters_for_indexing_spec.rb
+++ b/spec/api/sanitize_control_characters_for_indexing_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+describe RSolr::SanitizeControlCharactersForIndexing do
+  describe '.sanitize_document' do
+    it "preserves tabs, newline, and form feed control characters but replaces others with a blank" do
+      expect(described_class.sanitize_document({hello: "w\n\foot"})).to eq({ hello: "w\n oot" })
+    end
+  end
+  describe '.sanitize_value' do
+    it "preserves tabs, newline, and form feed control characters but replaces others with a blank" do
+      given = "a\tb\nc\fd\re"
+      expected = "a\tb\nc d\re"
+      expect(described_class.sanitize_value(given)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, if a document contained unexpected control
characters – not "\t", "\n", or "\r" the indexing process would fail.
With this commit, we are using the SanitizeControlCharactersForIndexing
module to ensure extra control characters are not part of the add
to solr document request.

Related to projecthydra/active_fedora#1154