### PR TITLE
default_wt should be JSON not eval'd Ruby.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -155,14 +155,13 @@ Delete by array of queries
 == Response Formats
 The default response format is Ruby. When the +:wt+ param is set to +:ruby+, the response is eval'd resulting in a Hash. You can get a raw response by setting the +:wt+ to +"ruby"+ - notice, the string -- not a symbol. RSolr will eval the Ruby string ONLY if the :wt value is :ruby. All other response formats are available as expected, +:wt=>'xml'+ etc..
 
-===Evaluated Ruby (default)
+===Evaluated Ruby:
   solr.get 'select', :params => {:wt => :ruby} # notice :ruby is a Symbol
-===Raw Ruby
+===Raw Ruby:
   solr.get 'select', :params => {:wt => 'ruby'} # notice 'ruby' is a String
-
 ===XML:
   solr.get 'select', :params => {:wt => :xml}
-===JSON:
+===JSON (default):
   solr.get 'select', :params => {:wt => :json}
 
 ==Related Resources & Projects

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -7,7 +7,7 @@ class RSolr::Client
 
   class << self
     def default_wt
-      @default_wt || :ruby
+      @default_wt || :json
     end
 
     def default_wt= value
@@ -319,21 +319,17 @@ class RSolr::Client
   # instead, giving full access to the
   # request/response objects.
   def evaluate_ruby_response request, response
-    begin
-      Kernel.eval response[:body].to_s
-    rescue SyntaxError
-      raise RSolr::Error::InvalidRubyResponse.new request, response
-    end
+    Kernel.eval response[:body].to_s
+  rescue SyntaxError
+    raise RSolr::Error::InvalidRubyResponse.new request, response
   end
 
   def evaluate_json_response request, response
-    return response[:body] unless defined? JSON
+    return if response[:body].nil? || response[:body].empty?
 
-    begin
-      JSON.parse response[:body].to_s
-    rescue JSON::ParserError
-      raise RSolr::Error::InvalidJsonResponse.new request, response
-    end
+    JSON.parse response[:body].to_s
+  rescue JSON::ParserError
+    raise RSolr::Error::InvalidJsonResponse.new request, response
   end
 
   def default_wt

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe RSolr::Client do
 
     context "when params are symbols" do
       it 'should return a request context array' do
-        [/fq=0/, /fq=1/, /q=test/, /wt=ruby/].each do |pattern|
+        [/fq=0/, /fq=1/, /q=test/, /wt=json/].each do |pattern|
           expect(subject[:query]).to match pattern
         end
         expect(subject[:data]).to eq("data")
@@ -338,11 +338,11 @@ RSpec.describe RSolr::Client do
       let(:options) { { method: :post, data: data, headers: {} } }
 
       it "sets the Content-Type header to application/x-www-form-urlencoded; charset=UTF-8" do
-        expect(subject[:query]).to eq("wt=ruby")
+        expect(subject[:query]).to eq("wt=json")
         [/fq=0/, /fq=1/, /q=test/].each do |pattern|
           expect(subject[:data]).to match pattern
         end
-        expect(subject[:data]).not_to match /wt=ruby/
+        expect(subject[:data]).not_to match /wt=json/
         expect(subject[:headers]).to eq({"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"})
       end
     end
@@ -354,6 +354,6 @@ RSpec.describe RSolr::Client do
         :headers => {}
       )
       expect(result[:uri].to_s).to match /^http:\/\/localhost:9999\/solr\//
-    end 
+    end
   end
 end

--- a/spec/api/pagination_spec.rb
+++ b/spec/api/pagination_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RSolr::Client do
         :params => {
           "rows" => 10,
           "start" => 0,
-          :wt => :ruby
+          :wt => :json
         }
       }))
       c.paginate 1, 10, "select"


### PR DESCRIPTION
For both performance and security reasons, it's much better to default to using JSON rather than using Ruby code and invoking Ruby's parse and interpreter to eval responses from Solr.