### PR TITLE
Fixes Faraday rescue with versions < 0.9.0

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -189,7 +189,7 @@ class RSolr::Client
       end
 
       { status: response.status.to_i, headers: response.headers, body: response.body.force_encoding('utf-8') }
-    rescue Faraday::ClientError => e
+    rescue Faraday::Error => e
       raise RSolr::Error::Http.new(request_context, e.response)
     rescue Errno::ECONNREFUSED
       raise RSolr::Error::ConnectionRefused, request_context.inspect


### PR DESCRIPTION
Faraday versions < 0.9.0 use `Faraday::Error::ClientError` while > 0.9.0 use `Faraday::ClientError`. Any app using rsolr and an 0.8 version of Faraday will see errors. Since both versions inherit from `Error` this should be a quick fix.

[Faraday 0.8](https://github.com/lostisland/faraday/blob/0.8/lib/faraday/error.rb)
[Faraday 0.9](https://github.com/lostisland/faraday/blob/0.9/lib/faraday/error.rb)