### PR TITLE
Check that the url is HTTP/HTTPS

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'faraday'
 
 class RSolr::Client
+  DEFAULT_URL = 'http://127.0.0.1:8983/solr/'
 
   class << self
     def default_wt
@@ -19,9 +22,7 @@ class RSolr::Client
     @proxy = @uri = nil
     @connection = connection
     unless false === options[:url]
-      url = options[:url] ? options[:url].dup : 'http://127.0.0.1:8983/solr/'
-      url << "/" unless url[-1] == ?/
-      @uri = ::URI.parse(url)
+      @uri = extract_url_from_options(options)
       if options[:proxy]
         proxy_url = options[:proxy].dup
         proxy_url << "/" unless proxy_url.nil? or proxy_url[-1] == ?/
@@ -33,6 +34,15 @@ class RSolr::Client
     @update_format = options.delete(:update_format) || RSolr::JSON::Generator
     @update_path = options.fetch(:update_path, 'update')
     @options = options
+  end
+
+  def extract_url_from_options(options)
+    url = options[:url] ? options[:url].dup : DEFAULT_URL
+    url << "/" unless url[-1] == ?/
+    uri = ::URI.parse(url)
+    # URI::HTTPS is a subclass of URI::HTTP, so this check accepts HTTP(S)
+    raise ArgumentError, "You must provide an HTTP(S) url." unless uri.kind_of?(URI::HTTP)
+    uri
   end
 
   # returns the request uri object.

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe RSolr::Client do
   let(:connection) { nil }
-  let(:connection_options) { { url: "http://localhost:9999/solr", read_timeout: 42, open_timeout: 43, update_format: :xml } }
+  let(:url) { "http://localhost:9999/solr" }
+  let(:connection_options) { { url: url, read_timeout: 42, open_timeout: 43, update_format: :xml } }
 
   let(:client) do
     RSolr::Client.new connection, connection_options
@@ -41,6 +42,23 @@ RSpec.describe RSolr::Client do
       client = RSolr::Client.new(:whatevs, { proxy: false })
       expect(client.proxy).to eq(false)
     end
+
+    context "with an non-HTTP url" do
+      let(:url) { "fake://localhost:9999/solr" }
+
+      it "raises an argument error" do
+        expect { client }.to raise_error ArgumentError, "You must provide an HTTP(S) url."
+      end
+    end
+
+    context "with an HTTPS url" do
+      let(:url) { "https://localhost:9999/solr" }
+
+      it "creates a connection" do
+        expect(client.uri).to be_kind_of URI::HTTPS
+      end
+    end
+
   end
 
   context "send_and_receive" do


### PR DESCRIPTION
Faraday makes the assumption that it can call `#request_uri` on the
passed in URI. This method is only on the interface for URI::HTTP and
URI::HTTPS