### PR TITLE
Require faraday >= 0.9.0 for use of Faraday::FlatParamsEncoder

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Apache Solr'
 
   s.add_dependency 'builder', '>= 2.1.2'
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '>= 0.9.0'
 
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'nokogiri', '>= 1.4.0'


### PR DESCRIPTION
Use of Faraday::FlatParamsEncoder was added in https://github.com/rsolr/rsolr/commit/65017d8e608d8690c5061a28ecae2c3a93d39e90. This only exists in faraday >= 0.9.0.

Update the version requirement for faraday.