### PR TITLE
Add missing "require 'uri'"

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'faraday'
+require 'uri'
 
 class RSolr::Client
 


### PR DESCRIPTION
Fixes error about `unitialized constant URI` upon `RSolr.connect`.