### PR TITLE
Updates tested rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - jruby-9.1.7.0
+  - 2.6
+  - 2.5
+  - 2.4
+  - jruby
 
 env:
   global:
     - JRUBY_OPTS="-J-Xms512m -J-Xmx1024m"
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
-jdk: oraclejdk8
+jdk: openjdk8


### PR DESCRIPTION
MRI:
- Added 2.5, 2.6
- Dropped 2.2, 2.3

JRuby:
- Changed to latest RVM version ("jruby")
- JDK changed from oraclejdk8 to openjdk8