### PR TITLE
Remove rubyforge_project

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.email       = ["goodieboy@gmail.com"]
   s.license     = 'Apache-2.0'
   s.homepage    = "https://github.com/rsolr/rsolr"
-  s.rubyforge_project = "rsolr"
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Gem::Specification#rubyforge_project= is deprecated with no replacement