### PR TITLE
Bugfix: failure of generating error-logs when a HTTP response body includes multibyte-chars

### DIFF
--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -110,9 +110,16 @@ module RSolr::Error
     }
 
     def initialize request, response
+      response = response_with_force_encoded_body(response)
       @request, @response = request, response
     end
 
+    private
+
+    def response_with_force_encoded_body(response)
+      response[:body] = response[:body].force_encoding('UTF-8')
+      response
+    end
   end
 
   # Thrown if the :wt is :ruby

--- a/spec/api/error_spec.rb
+++ b/spec/api/error_spec.rb
@@ -43,5 +43,13 @@ RSpec.describe RSolr::Error do
       let(:response_body) { (response_lines << "'error'=>{'msg'=> #{msg}").join("\n") }
       it { should include msg }
     end
+
+    context "when the response body is made of multi-byte chars and encoded by ASCII-8bit" do
+      let (:response_lines) { (1..15).to_a.map { |i| "レスポンス #{i}".b } }
+
+      it "encodes errorlogs by UTF-8" do
+        expect(subject.encoding.to_s).to eq 'UTF-8'
+      end
+    end
   end
 end


### PR DESCRIPTION
I found a bug that `Encoding::CompatibilityError` is raised on `Rsolr::Error::SolrContext#to_s` and fixed it.

The error occurs during generating error-logs after `Rsolr::Client#execute` is received a response whose status is 4xx and body includes multibyte-characters(cf: Japanese).

```
     Failure/Error: m << p
     
     Encoding::CompatibilityError:
       incompatible character encodings: ASCII-8BIT and UTF-8
     # ./lib/rsolr/error.rb:22:in `to_s'
```