### PR TITLE
Separate our new RSolr::Error::Timeout from generic RSolr::Error::Http

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -200,6 +200,8 @@ class RSolr::Client
       end
 
       { status: response.status.to_i, headers: response.headers, body: response.body.force_encoding('utf-8') }
+    rescue Faraday::TimeoutError => e
+      raise RSolr::Error::Timeout.new(request_context, e.response)
     rescue Errno::ECONNREFUSED, defined?(Faraday::ConnectionFailed) ? Faraday::ConnectionFailed : Faraday::Error::ConnectionFailed
       raise RSolr::Error::ConnectionRefused, request_context.inspect
     rescue Faraday::Error => e
@@ -283,7 +285,7 @@ class RSolr::Client
 
     result
   end
-  
+
   def connection
     @connection ||= begin
       conn_opts = { request: {} }

--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -121,6 +121,15 @@ module RSolr::Error
 
   end
 
+  # Subclasses Rsolr::Error::Http for legacy backwards compatibility
+  # purposes, because earlier RSolr 2 didn't distinguish these
+  # from Http errors.
+  #
+  # In RSolr 3, it could make sense to `< Timeout::Error` instead,
+  # analagous to ConnectionRefused above
+  class Timeout < Http
+  end
+
   # Thrown if the :wt is :ruby
   # but the body wasn't succesfully parsed/evaluated
   class InvalidJsonResponse < InvalidResponse

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe RSolr::Client do
     end
   end
 
+  context "execute" do
+    it "maps Faraday::TimeoutError to an RSolr::Error::Timeout" do
+      allow(client.connection).to receive(:send).and_raise(Faraday::TimeoutError)
+
+      expect{ client.execute({}) }.to raise_error RSolr::Error::Timeout
+    end
+  end
+
   context "post" do
     it "should pass the expected params to the connection's #execute method" do
       request_opts = {:data => "the data", :method=>:post, :headers => {"Content-Type" => "text/plain"}}
@@ -342,7 +350,7 @@ RSpec.describe RSolr::Client do
         expect(subject[:headers]).to eq({"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"})
       end
     end
-   
+
     it "should properly handle proxy configuration" do
       result = client_with_proxy.build_request('select',
         :method => :post,


### PR DESCRIPTION
Prior to this PR, *some* kinds of faraday timeouts (on connection, faraday raises as Faraday::ConnectionFailed) wind up being raised as RSolr::Error::ConnectionRefused. But read timeouts (Raised as Faraday::TimeoutError) end up being lumped in with 4xx and 5xx responses, raised as RSolr::Error::Http.

It makes sense to treat Faraday::TimeoutError more analagously with Faraday::ConnectionRefused (connection timeout), so they can easily be distinguished by rescues. For instance, Blacklight will currenty re-raise a Faraday::ConnectionRefused, but swallow all Rsolr::Error::Http. This change will make it more straightforward for Blacklight to begin handling read timeouts the same way it does connection timeouts, instead.

We create a new Rsolr::Error::Timeout, and raise that from Faraday::TimeoutError. (Confirmed Faraday::TimeoutError exists all the way back to Faraday 0.9.0, the oldest Faraday RSolr currently supports: https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/error.rb#L40-L44)

For backwards compatibility, we make Rsolr::Error::Timeout a subclass of RSolr::Error::Http.  This way, any existing software that was rescueing a timeout exhibiting as Rsolr::Error::Http and treating it a certain way -- will continue doing the same when it's raised as the more particular sub-class, backwards compatibly. If we were starting from scratch, we probably would NOT have Rsolr::Error::Timeout subclass Rsolr::Error::Http (the analagous Rsolr::Error::Connection refused does not) -- but trying to be as careful as possible with backwards compat.

For more context: https://bibwild.wordpress.com/2021/10/11/setting-and-handling-solr-timeouts-in-blacklight/

It's true that there are no tests here -- there were no tests to any timeout behavior (including ConnectionRefused) before either, so this is no loss of test coverage. I couldn't figure out any way to do tests that made any sense. If anyone has an idea, please do share.  I did test manually. 