### PR TITLE
Pass `timeout` arg directly to faraday, deprecate `read_timeout`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,8 +50,10 @@ By default, RSolr uses the Solr JSON command format for all requests.
   RSolr.connect :url => 'http://solrserver.com', update_format: :xml
 
 == Timeouts
-The read and connect timeout settings can be set when creating a new instance of RSolr:
-  solr = RSolr.connect(:read_timeout => 120, :open_timeout => 120)
+The read and connect timeout settings can be set when creating a new instance of RSolr, and will
+be passed on to underlying Faraday instance:
+
+  solr = RSolr.connect(:timeout => 120, :open_timeout => 120)
 
 == Retry 503s
 A 503 is usually a temporary error which RSolr may retry if requested. You may specify the number of retry attempts with the +:retry_503+ option.

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -35,6 +35,10 @@ class RSolr::Client
     @update_format = options.delete(:update_format) || RSolr::JSON::Generator
     @update_path = options.fetch(:update_path, 'update')
     @options = options
+
+    if options[:read_timeout]
+      warn "DEPRECATION: Rsolr.new/connect option `read_timeout` is deprecated and will be removed in Rsolr 3. `timeout` is currently a synonym, use that instead."
+    end
   end
 
   def extract_url_from_options(options)
@@ -283,14 +287,20 @@ class RSolr::Client
 
     result
   end
-  
+
   def connection
     @connection ||= begin
       conn_opts = { request: {} }
       conn_opts[:url] = uri.to_s
       conn_opts[:proxy] = proxy if proxy
       conn_opts[:request][:open_timeout] = options[:open_timeout] if options[:open_timeout]
-      conn_opts[:request][:timeout] = options[:read_timeout] if options[:read_timeout]
+
+      if options[:read_timeout] || options[:timeout]
+        # read_timeout was being passed to faraday as timeout since Rsolr 2.0,
+        # it's now deprecated, just use `timeout` directly.
+        conn_opts[:request][:timeout] = options[:timeout] || options[:read_timeout]
+      end
+
       conn_opts[:request][:params_encoder] = Faraday::FlatParamsEncoder
 
       Faraday.new(conn_opts) do |conn|

--- a/spec/lib/rsolr/client_spec.rb
+++ b/spec/lib/rsolr/client_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe RSolr::Client do
+  describe "#connection" do
+    it "accepts a timeout parameter it passes to Faraday" do
+      client = described_class.new(nil, timeout: 1000)
+
+      expect(client.connection.options[:timeout]).to eq 1000
+    end
+    it "accepts a deprecated read_timeout" do
+      client = nil
+      expect do
+        client = described_class.new(nil, read_timeout: 1000)
+      end.to output(/`read_timeout` is deprecated/).to_stderr
+
+      expect(client.connection.options[:timeout]).to eq 1000
+    end
+  end
+end


### PR DESCRIPTION
Since RSolr 2.0, the `read_timeout` option given to Rsolr.connect is translated to a `timeout` option passed to the underlying Faraday object.

This makes a confusing situation even more confusing. Why not just take and pass a `timeout` option as `timeout` to Faraday? This PR does that. For backwards compatibilty, if you pass read_timeout, it will still also be passed as Faraday `timeout` (same as it was before this PR), but a deprecation message will be printed out. (Using `warn`, which the codebase already has one instance of using for a deprecation warning, so I just followed suit).

Really for at least some adapters, Faraday supports all of: `timeout`, `read_timeout`, `write_timeout`, and `open_timeout`. Ideally we might allow and pass ALL of these on to Faraday... but there's no great way to do that backwards compatibly when previous RSolr took `read_timeout` and passed it as `timeout`! So one step at a time, don't change what functionality is supported, just make the name direct, as a stepping stone to supporting more Faraday timeout options.

There were no tests for this behavior previously. I have added no tests. I could not figure out any reasonable way to write a test here; if anyone has one, suggestions welcome. There is no drop in test coverage, but this is not ideal.

Test failures are unrelated to this PR, and I don't know how to fix them.