### PR TITLE
Revert "Bugfix: failure of generating error-logs when a HTTP response body includes multibyte-chars"

### DIFF
--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -124,16 +124,9 @@ module RSolr::Error
     }
 
     def initialize request, response
-      response = response_with_force_encoded_body(response)
       @request, @response = request, response
     end
 
-    private
-
-    def response_with_force_encoded_body(response)
-      response[:body] = response[:body].force_encoding('UTF-8')
-      response
-    end
   end
 
   # Thrown if the :wt is :ruby

--- a/spec/api/error_spec.rb
+++ b/spec/api/error_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe RSolr::Error do
       let(:response_body) { (response_lines << "'error'=>{'msg'=> #{msg}").join("\n") }
       it { should include msg }
     end
-
-    context "when the response body is made of multi-byte chars and encoded by ASCII-8bit" do
-      let (:response_lines) { (1..15).to_a.map { |i| "レスポンス #{i}".b } }
-
-      it "encodes errorlogs by UTF-8" do
-        expect(subject.encoding.to_s).to eq 'UTF-8'
-      end
-    end
   end
 
   context "when response is JSON" do


### PR DESCRIPTION
Reverts rsolr/rsolr#208

Experimental pull request to see if CI is green on this.