### PR TITLE
guard against nil response

### DIFF
--- a/lib/rsolr/error.rb
+++ b/lib/rsolr/error.rb
@@ -131,7 +131,7 @@ module RSolr::Error
     private
 
     def response_with_force_encoded_body(response)
-      response[:body] = response[:body].force_encoding('UTF-8')
+      response[:body] = response[:body].force_encoding('UTF-8') if response
       response
     end
   end


### PR DESCRIPTION
Apparently response can be nil in some cases. Fix to what was in #208 to avoid that introducing a regression in cases where response is nil.
