### PR TITLE
Avoid using deprecated read_timeout in tests

### DIFF
--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe RSolr::Client do
   let(:connection) { nil }
   let(:url) { "http://localhost:9999/solr" }
-  let(:connection_options) { { url: url, read_timeout: 42, open_timeout: 43, update_format: :xml } }
+  let(:connection_options) { { url: url, update_format: :xml } }
 
   let(:client) do
     RSolr::Client.new connection, connection_options
@@ -117,7 +117,7 @@ RSpec.describe RSolr::Client do
 
     context 'when the client is configured for json updates' do
       let(:client) do
-        RSolr::Client.new nil, :url => "http://localhost:9999/solr", :read_timeout => 42, :open_timeout=>43, :update_format => :json
+        RSolr::Client.new nil, :url => "http://localhost:9999/solr", :update_format => :json
       end
       it "should send json to the connection's #post method" do
         expect(client).to receive(:execute).


### PR DESCRIPTION
read_timeout was deprecated in #215, but some tests still using it, cluttering up the console output with deprecation warnings.

read_timeout was not necessary in tests for them to pass; it wasn't doing anything. In fact, the `open_timeout` value that hasn't done anything since RSolr 2.0 was in the tests too, as a no-op, possibly giving a false sense of security.

Removed timeout config from tests that were green anyway without them, where they weren't being tested.
