### PR TITLE
restrict faraday version to 1.x

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Apache Solr'
 
   s.add_dependency 'builder', '>= 2.1.2'
-  s.add_dependency 'faraday', '>= 0.9.0'
+  s.add_dependency 'faraday', '~> 1.0'
 
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'nokogiri', '>= 1.4.0'


### PR DESCRIPTION
Faraday 2.0 release as of 2022-01-04 requires selecting an adapter, which can break many apps.  This restricts the version to use 1.x versions.  Error messages look like:

``` RuntimeError:
       An attempt to run a request with a Faraday::Connection without adapter has been made.
       Please set Faraday.default_adapter or provide one when initializing the connection.
       For more info, check https://lostisland.github.io/faraday/usage/.
```

Faraday release https://github.com/lostisland/faraday/releases/tag/v2.0.0