### PR TITLE
Relax faraday dependency pinning

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'faraday'
-require 'faraday/net_http'
 require 'uri'
 
 class RSolr::Client

--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -33,8 +33,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Apache Solr'
 
   s.add_dependency 'builder', '>= 2.1.2'
-  s.add_dependency 'faraday', '>= 1'
-  s.add_dependency 'faraday-net_http'
+  s.add_dependency 'faraday', '>= 0.9', '!= 2.0.0', '< 3'
 
   s.add_development_dependency 'activesupport'
   s.add_development_dependency 'nokogiri', '>= 1.4.0'


### PR DESCRIPTION
faraday 2.0.1 is sufficiently compatible with 0.x and 1.x dependencies.