### PR TITLE
Removing credentials from uri when assembling error message

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+2.6.0
+
+- Sanitizing URIs displayed in error messages. https://github.com/rsolr/rsolr/pull/236
+
+2.5.0
+
+- Sorry, not human-edited: https://github.com/rsolr/rsolr/compare/v2.4.0...v2.5.0
+
+
 2.4.0
 
 - Raise specific timeout error for solr timeouts. https://github.com/rsolr/rsolr/pull/214

--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -215,7 +215,7 @@ class RSolr::Client
     rescue Faraday::TimeoutError => e
       raise RSolr::Error::Timeout.new(request_context, e.response)
     rescue Errno::ECONNREFUSED, defined?(Faraday::ConnectionFailed) ? Faraday::ConnectionFailed : Faraday::Error::ConnectionFailed
-      raise RSolr::Error::ConnectionRefused, request_context.inspect
+      raise RSolr::Error::ConnectionRefused.new(request_context)
     rescue Faraday::Error => e
       raise RSolr::Error::Http.new(request_context, e.response)
     end

--- a/spec/api/error_spec.rb
+++ b/spec/api/error_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RSolr::Error do
     exception
   end
   let (:response_lines) { (1..15).to_a.map { |i| "line #{i}" } }
-  let(:request)  { double :[] => "mocked" }
+  let(:request) { { uri: URI.parse('http://hostname.local:8983/solr/admin/update?wt=json&q=test') } }
   let(:response_body) { response_lines.join("\n") }
   let(:response) {{
     :body   => response_body,
@@ -89,7 +89,7 @@ RSpec.describe RSolr::Error do
             "code":500
           }
         }
-        EOS
+      EOS
       }
       it {
         should include msg
@@ -116,7 +116,7 @@ RSpec.describe RSolr::Error do
             "facet_fields":{}
           },
         }
-        EOS
+      EOS
       }
       it "shows the first eleven lines of the response" do
         expect(subject).to include(response_body.split("\n")[0..10].join("\n"))
@@ -144,6 +144,15 @@ RSpec.describe RSolr::Error do
     it "shows the first eleven lines of the response" do
       expect(subject).to include(response_body.split("\n")[0..10].join("\n"))
       expect(subject).not_to include(response_body.split("\n")[11])
+    end
+  end
+
+  context "when request uri contains credentials" do
+    let(:request) { { uri: URI.parse('http://admin:admin@hostname.local:8983/solr/admin/update?wt=json&q=test') } }
+
+
+    it 'includes redacted url' do
+      expect(subject).to include 'http://REDACTED:REDACTED@hostname.local:8983/solr/admin/update?wt=json&q=test'
     end
   end
 end


### PR DESCRIPTION
Closes #235 

The credentials in the URI are exposed in both the `RSolr::Error::Http` and in the `RSolr::Error::ConnectionRefused` classes. This is my attempt at removing the credentials from the URI while keeping the error message returned from these classes the same. 

There's some more refactoring that could happen in these error classes, but it would change the output that they return. The `RSolr::Error::ConnectionRefused` could potentially just return the URI instead of a serialized version of the request context. 
`RSolr::Error::ConnectionRefused` could also inherit from `RSolr::Error::Http` and use the same `to_s` method, but that would be an API change.