### PR TITLE
allow testing against solr 9.5.0

### DIFF
--- a/spec/fixtures/basic_configs/schema.xml
+++ b/spec/fixtures/basic_configs/schema.xml
@@ -498,7 +498,7 @@
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
 
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField"/> 
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:

--- a/spec/integration/solr5_spec.rb
+++ b/spec/integration/solr5_spec.rb
@@ -4,7 +4,7 @@ require 'solr_wrapper'
 RSpec.describe "Solr basic_configs" do
   SolrWrapper.default_instance_options = {
     port: SolrWrapper.default_solr_port,
-    version: '8.11.3'
+    version: '9.5.0'
   } 
   SOLR_INSTANCE =  SolrWrapper.default_instance({})
   before(:all) { SOLR_INSTANCE.start }


### PR DESCRIPTION
`solr.LatLonType` was deprecated in Solr 7 and is not included in Solr 9; this was breaking CI builds.

Uses `9.5.0` as the Solr version in the rspec tests.