### PR TITLE
Get tests passing with recent versions of URI and JSON gems

### DIFF
--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RSolr::Client do
       it "removes credentials from uri" do
         expect {
           client.execute({ uri: uri })
-        }.to raise_error(RSolr::Error::ConnectionRefused, /http:\/\/REDACTED:REDACTED@hostname\.local:8983/)
+        }.to raise_error(RSolr::Error::ConnectionRefused, /http:\/\/(?:REDACTED:)?REDACTED@hostname\.local:8983/)
       end
     end
   end

--- a/spec/api/error_spec.rb
+++ b/spec/api/error_spec.rb
@@ -148,11 +148,13 @@ RSpec.describe RSolr::Error do
   end
 
   context "when request uri contains credentials" do
-    let(:request) { { uri: URI.parse('http://admin:admin@hostname.local:8983/solr/admin/update?wt=json&q=test') } }
+    let(:request) { { uri: URI.parse('http://user:pass@hostname.local:8983/solr/admin/update?wt=json&q=test') } }
 
 
     it 'includes redacted url' do
-      expect(subject).to include 'http://REDACTED:REDACTED@hostname.local:8983/solr/admin/update?wt=json&q=test'
+      expect(subject).to include 'REDACTED@hostname.local:8983/solr/admin/update?wt=json&q=test'
+      expect(subject).not_to include 'user'
+      expect(subject).not_to include 'pass'
     end
   end
 end

--- a/spec/api/json_spec.rb
+++ b/spec/api/json_spec.rb
@@ -68,32 +68,10 @@ RSpec.describe RSolr::JSON do
           },
         ]
 
-        # custom JSON object class to handle Solr's non-standard JSON command format
-        tmp = Class.new do
-          def initialize
-            @source ||= {}
-          end
-
-          def []=(k, v)
-            if k == :add
-              @source[k] ||= []
-              @source[k] << v.to_h
-            elsif v.class == self.class
-              @source[k] = v.to_h
-            else
-              @source[k] = v
-            end
-          end
-
-          def to_h
-            @source
-          end
-        end
-
         request = generator.add(data, boost: 1)
-        message = JSON.parse(request, object_class: tmp, symbolize_names: true).to_h
-        expect(message[:add].length).to eq 2
-        expect(message[:add].map { |x| x[:doc] }).to eq data
+
+        expect(request).to match /"add":{"boost":1,"doc":{"id":"1","name":"matt"}}/
+        expect(request).to match /"add":{"boost":1,"doc":{"id":"2","name":"sam"}}/
       end
     end
 


### PR DESCRIPTION
* The URI gem's version 1.0.4 addresses CVE-2025-61594.  This fix has the side effect of removing the (already redacted) password from our error messages,   so our test assertions needed to be updated for compatibility with versions of the gem both before and after the fix.
* As of version 2.11.0 of the JSON gem, we had a failing test.  When newer versions of the JSON gem parse a json string with duplicate keys, it ignores all but the last value completely, rather than making them available to our custom class.  I don't love this solution; it seems brittle and does not assert the order or cardinality of the data.  But it is better than a failing test.

Note that CI won't run until #249 is merged...