### PR TITLE
Raise more specific ArgumentError and fix guard clause

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -75,7 +75,7 @@ class RSolr::Client
   def paginate page, per_page, path, opts = nil
     opts ||= {}
     opts[:params] ||= {}
-    raise "'rows' or 'start' params should not be set when using +paginate+" if ["start", "rows"].include?(opts[:params].keys)
+    raise ArgumentError, "'rows' or 'start' params should not be set when using +paginate+" if opts[:params].keys.any? { |k| ["start", "rows", :start, :rows].include?(k) }
     execute build_paginated_request(page, per_page, path, opts)
   end
 

--- a/spec/api/pagination_spec.rb
+++ b/spec/api/pagination_spec.rb
@@ -27,5 +27,12 @@ RSpec.describe RSolr::Client do
       }))
       c.paginate 1, 10, "select"
     end
+    it "should raise an error when rows or start params passed in opts (as either string or symbol keys)" do
+      c = RSolr::Client.new(nil, {})#.extend(RSolr::Pagination::Client)
+      allow(c).to receive(:execute)
+      expect { c.paginate 1, 10, "select", params: { "start" => 0, "rows" => 10 } }.to raise_error(ArgumentError)
+      expect { c.paginate 1, 10, "select", params: { start: 0, rows: 10 } }.to raise_error(ArgumentError)
+      expect { c.paginate 1, 10, "select", params: {} }.not_to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
In my local Samvera app I came across this problem where rsolr wasn't raising an error when a `:rows` param was passed in opts which masked a problem.  This PR should fix that problem and properly raise an error.  (I changed it to an ArgumentError to be more specific.)  I'm a bit hesitant to submit this PR because raising the error will be a change in behavior that will break some parts of ActiveFedora which incorrectly pass these params.  (See https://github.com/samvera/active_fedora/blob/3ce77e394d586de523c91af2c59a2aeb1fa2a6b3/lib/active_fedora/relation.rb#L52-L59 which eventually calls `paginate`).