### PR TITLE
Allow for setting a default http method

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -15,6 +15,14 @@ class RSolr::Client
     def default_wt= value
       @default_wt = value
     end
+
+    def default_http_method
+      @default_http_method ||= :get
+    end
+
+    def default_http_method= method
+      @default_http_method = method
+    end
   end
 
   attr_reader :uri, :proxy, :update_format, :options, :update_path
@@ -240,7 +248,7 @@ class RSolr::Client
     raise "path must be a string or symbol, not #{path.inspect}" unless [String,Symbol].include?(path.class)
     path = path.to_s
     opts[:proxy] = proxy unless proxy.nil?
-    opts[:method] ||= :get
+    opts[:method] ||= default_http_method
     raise "The :data option can only be used if :method => :post" if opts[:method] != :post and opts[:data]
     opts[:params] = params_with_wt(opts[:params])
     query = RSolr::Uri.params_to_solr(opts[:params]) unless opts[:params].empty?
@@ -368,5 +376,9 @@ class RSolr::Client
 
   def default_wt
     self.options[:default_wt] || self.class.default_wt
+  end
+
+  def default_http_method
+    self.options[:default_http_method] || self.class.default_http_method
   end
 end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -419,5 +419,24 @@ RSpec.describe RSolr::Client do
       )
       expect(result[:uri].to_s).to match %r{^http://localhost:9999/solr/}
     end
+
+    context "http method" do
+      it "uses get by default" do
+        expect(client.build_request('select', { params: params })[:method]).to eq :get
+      end
+      it "uses the instance default if set" do
+        client = RSolr::Client.new connection, connection_options.merge(default_http_method: :post)
+        expect(client.build_request('select', { data: params })[:method]).to eq :post
+      end
+      it "uses the class default if set" do
+        RSolr::Client.default_http_method = :post
+        expect(client.build_request('select', { data: params })[:method]).to eq :post
+        RSolr::Client.default_http_method = nil
+      end
+      it "uses the method passed in opts" do
+        expect(client.build_request('select', { params: params, method: :get })[:method]).to eq :get
+        expect(client.build_request('select', { data: params, method: :post })[:method]).to eq :post
+      end
+    end
   end
 end


### PR DESCRIPTION
Solr requests in my application can get to be very large requiring us to use post instead of get.  We have a few dependencies alongside our app which use rsolr to make requests and we found it easiest to set a default http method at this low level to ensure that all solr requests use post.  I followed the pattern of `default_wt` already present in `Client` where it prefers `:method` passed in `opts` over an instance option over the class default.  The class default is `:get` for backwards compatibility.