### PR TITLE
Be helpful and move query params into data hash when using post and no data is provided

### DIFF
--- a/lib/rsolr/client.rb
+++ b/lib/rsolr/client.rb
@@ -243,8 +243,14 @@ class RSolr::Client
     opts[:method] ||= :get
     raise "The :data option can only be used if :method => :post" if opts[:method] != :post and opts[:data]
     opts[:params] = params_with_wt(opts[:params])
-    query = RSolr::Uri.params_to_solr(opts[:params]) unless opts[:params].empty?
-    opts[:query] = query
+    if opts[:method] == :post && (opts[:data].nil? || opts[:data].empty?)
+      # If no data hash is provided move query into data hash
+      # This is useful if the query string is larger than the max url length
+      opts[:data] = opts[:params]
+    else
+      query = RSolr::Uri.params_to_solr(opts[:params]) unless opts[:params].empty?
+      opts[:query] = query
+    end
     if opts[:data].is_a? Hash
       opts[:data] = RSolr::Uri.params_to_solr opts[:data]
       opts[:headers] ||= {}

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -411,6 +411,18 @@ RSpec.describe RSolr::Client do
       end
     end
 
+    context "when post but no hash is passed in as data" do
+      let(:data) { nil }
+
+      it "sets the Content-Type header to application/x-www-form-urlencoded; charset=UTF-8" do
+        expect(subject[:query]).to be_nil
+        [/fq=0/, /fq=1/, /q=test/, /wt=json/].each do |pattern|
+          expect(subject[:data]).to match pattern
+        end
+        expect(subject[:headers]).to eq({"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"})
+      end
+    end
+
     it "should properly handle proxy configuration" do
       result = client_with_proxy.build_request('select',
         :method => :post,


### PR DESCRIPTION
The `build_request` method requires that you know ahead of time if you're using `get` or `post` requests in order to pass the solr query as either `params` or `data`.  An application might decide to set a default http method for rsolr (#252) and not have control over all of the solr calls being made using rsolr in order to use the appropriate method.  This isn't usually a problem because query params get added to the URL even for post requests and solr works.  A problem arises when a query is so large that it overruns the max URL length.   This PR tries to resolve that by being helpful and moving the `params` hash into `data` when none is provided so the URL stays small and the request can still complete.